### PR TITLE
Fix root POM to not implicitly introduce compile-scoped JUnit dependency

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -121,7 +121,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -143,7 +142,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,20 @@
     <groupId>io.split.client</groupId>
     <artifactId>java-client-parent</artifactId>
     <version>2.0.3-rc2</version>
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.21</version>
-        </dependency>
-    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.12</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <packaging>pom</packaging>
     <name>Java Client</name>
     <description>Java SDK for Split</description>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The current Java SDK ends up pulling in JUnit as a `compile`-scoped dependency. To see this, create a folder with the POM

```
<?xml version="1.0" encoding="UTF-8"?>
<project>
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.example</groupId>
  <artifactId>mylib</artifactId>
  <version>1.0</version>
  <dependencies>
    <dependency>
        <groupId>io.split.client</groupId>
        <artifactId>java-client</artifactId>
        <version>2.0.2</version>
    </dependency>
  </dependencies>
</project>
```

and then run ` mvn dependency:tree`:

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ mylib ---
[INFO] com.example:mylib:jar:1.0
[INFO] \- io.split.client:java-client:jar:2.0.2:compile
[INFO]    +- com.google.guava:guava:jar:18.0:compile
[INFO]    +- org.slf4j:slf4j-api:jar:1.7.12:compile
[INFO]    +- commons-logging:commons-logging:jar:1.2:compile
[INFO]    +- commons-codec:commons-codec:jar:1.9:compile
[INFO]    \- junit:junit:jar:4.12:compile
[INFO]       \- org.hamcrest:hamcrest-core:jar:1.3:compile
```

The problem here is that the root POM is using `<dependencies>` instead of `<dependencyManagement>`. Here, I've gone ahead and updated the POM to use `<dependencyManagement>` so you can manage versions centrally in the root POM but avoid adding dependencies to all subprojects. I manually verified that this fix removes the `compile`-scoped JUnit dependency.