### PR TITLE
Events impressions metrics redirect

### DIFF
--- a/client/src/main/java/io/split/client/EventClientImpl.java
+++ b/client/src/main/java/io/split/client/EventClientImpl.java
@@ -2,7 +2,7 @@ package io.split.client;
 
 import io.split.client.dtos.Event;
 import io.split.client.utils.GenericClientUtil;
-import org.apache.http.client.utils.URIBuilder;
+import io.split.client.utils.Utils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,15 +60,15 @@ public class EventClientImpl implements EventClient {
 
 
     public static EventClient create(CloseableHttpClient httpclient, URI eventsRootTarget, int maxQueueSize, long flushIntervalMillis, int waitBeforeShutdown) throws URISyntaxException {
-        return new EventClientImpl(new LinkedBlockingQueue<Event>(), httpclient, eventsRootTarget, maxQueueSize, flushIntervalMillis, waitBeforeShutdown);
+        return new EventClientImpl(new LinkedBlockingQueue<Event>(), httpclient,  Utils.appendPath(eventsRootTarget, "/api/events/bulk"), maxQueueSize, flushIntervalMillis, waitBeforeShutdown);
     }
 
-    EventClientImpl(BlockingQueue<Event> eventQueue, CloseableHttpClient httpclient, URI eventsRootTarget, int maxQueueSize,
+    EventClientImpl(BlockingQueue<Event> eventQueue, CloseableHttpClient httpclient, URI eventsTarget, int maxQueueSize,
                     long flushIntervalMillis, int waitBeforeShutdown) throws URISyntaxException {
 
         _httpclient = httpclient;
 
-        _eventsTarget = new URIBuilder(eventsRootTarget).setPath("/api/events/bulk").build();
+        _eventsTarget = eventsTarget;
 
         _eventQueue = eventQueue;
         _waitBeforeShutdown = waitBeforeShutdown;

--- a/client/src/main/java/io/split/client/EventClientImpl.java
+++ b/client/src/main/java/io/split/client/EventClientImpl.java
@@ -60,8 +60,8 @@ public class EventClientImpl implements EventClient {
     }
 
 
-    public static EventClient create(CloseableHttpClient httpclient, URI eventsRootTarget, int maxQueueSize, long flushIntervalMillis, int waitBeforeShutdown) throws URISyntaxException {
-        return new EventClientImpl(new LinkedBlockingQueue<Event>(), httpclient,  Utils.appendPath(eventsRootTarget, "/api/events/bulk"), maxQueueSize, flushIntervalMillis, waitBeforeShutdown);
+    public static EventClientImpl create(CloseableHttpClient httpclient, URI eventsRootTarget, int maxQueueSize, long flushIntervalMillis, int waitBeforeShutdown) throws URISyntaxException {
+        return new EventClientImpl(new LinkedBlockingQueue<Event>(), httpclient,  Utils.appendPath(eventsRootTarget, "api/events/bulk"), maxQueueSize, flushIntervalMillis, waitBeforeShutdown);
     }
 
     EventClientImpl(BlockingQueue<Event> eventQueue, CloseableHttpClient httpclient, URI target, int maxQueueSize,

--- a/client/src/main/java/io/split/client/impressions/HttpImpressionsSender.java
+++ b/client/src/main/java/io/split/client/impressions/HttpImpressionsSender.java
@@ -1,5 +1,6 @@
 package io.split.client.impressions;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.split.client.dtos.TestImpressions;
 import io.split.client.utils.Utils;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -21,16 +22,16 @@ public class HttpImpressionsSender implements ImpressionsSender {
     private static final Logger _logger = LoggerFactory.getLogger(HttpImpressionsSender.class);
 
     private CloseableHttpClient _client;
-    private URI _eventsEndpoint;
+    private URI _target;
 
 
-    public static HttpImpressionsSender create(CloseableHttpClient clinent, URI eventsRootEndpoint) throws URISyntaxException {
-        return new HttpImpressionsSender(clinent, Utils.appendPath(eventsRootEndpoint, "/api/testImpressions/bulk"));
+    public static HttpImpressionsSender create(CloseableHttpClient client, URI eventsRootEndpoint) throws URISyntaxException {
+        return new HttpImpressionsSender(client, Utils.appendPath(eventsRootEndpoint, "/api/testImpressions/bulk"));
     }
 
-    private HttpImpressionsSender(CloseableHttpClient client, URI eventsEndpoint) throws URISyntaxException {
+    private HttpImpressionsSender(CloseableHttpClient client, URI target) throws URISyntaxException {
         _client = client;
-        _eventsEndpoint = eventsEndpoint;
+        _target = target;
     }
 
     @Override
@@ -41,7 +42,7 @@ public class HttpImpressionsSender implements ImpressionsSender {
         try {
             StringEntity entity = Utils.toJsonEntity(impressions);
 
-            HttpPost request = new HttpPost(_eventsEndpoint);
+            HttpPost request = new HttpPost(_target);
             request.setEntity(entity);
 
             response = _client.execute(request);
@@ -60,4 +61,8 @@ public class HttpImpressionsSender implements ImpressionsSender {
 
     }
 
+    @VisibleForTesting
+    URI getTarget() {
+        return _target;
+    }
 }

--- a/client/src/main/java/io/split/client/impressions/HttpImpressionsSender.java
+++ b/client/src/main/java/io/split/client/impressions/HttpImpressionsSender.java
@@ -26,7 +26,7 @@ public class HttpImpressionsSender implements ImpressionsSender {
 
 
     public static HttpImpressionsSender create(CloseableHttpClient client, URI eventsRootEndpoint) throws URISyntaxException {
-        return new HttpImpressionsSender(client, Utils.appendPath(eventsRootEndpoint, "/api/testImpressions/bulk"));
+        return new HttpImpressionsSender(client, Utils.appendPath(eventsRootEndpoint, "api/testImpressions/bulk"));
     }
 
     private HttpImpressionsSender(CloseableHttpClient client, URI target) throws URISyntaxException {

--- a/client/src/main/java/io/split/client/impressions/HttpImpressionsSender.java
+++ b/client/src/main/java/io/split/client/impressions/HttpImpressionsSender.java
@@ -4,7 +4,6 @@ import io.split.client.dtos.TestImpressions;
 import io.split.client.utils.Utils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.slf4j.Logger;
@@ -24,9 +23,14 @@ public class HttpImpressionsSender implements ImpressionsSender {
     private CloseableHttpClient _client;
     private URI _eventsEndpoint;
 
-    public HttpImpressionsSender(CloseableHttpClient client, String eventsEndpoint) throws URISyntaxException {
+
+    public static HttpImpressionsSender create(CloseableHttpClient clinent, URI eventsRootEndpoint) throws URISyntaxException {
+        return new HttpImpressionsSender(clinent, Utils.appendPath(eventsRootEndpoint, "/api/testImpressions/bulk"));
+    }
+
+    private HttpImpressionsSender(CloseableHttpClient client, URI eventsEndpoint) throws URISyntaxException {
         _client = client;
-        _eventsEndpoint = new URIBuilder(eventsEndpoint).setPath("/api/testImpressions/bulk").build();
+        _eventsEndpoint = eventsEndpoint;
     }
 
     @Override

--- a/client/src/main/java/io/split/client/impressions/ImpressionsManager.java
+++ b/client/src/main/java/io/split/client/impressions/ImpressionsManager.java
@@ -9,6 +9,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,7 +62,7 @@ public class ImpressionsManager implements ImpressionListener, Runnable {
         if (impressionsSender != null) {
             _impressionsSender = impressionsSender;
         } else {
-            _impressionsSender = new HttpImpressionsSender(_client, config.eventsEndpoint());
+            _impressionsSender = HttpImpressionsSender.create(_client, URI.create(config.eventsEndpoint()));
         }
     }
 

--- a/client/src/main/java/io/split/client/impressions/ImpressionsManager.java
+++ b/client/src/main/java/io/split/client/impressions/ImpressionsManager.java
@@ -152,5 +152,4 @@ public class ImpressionsManager implements ImpressionListener, Runnable {
                     impressions.size(), (System.currentTimeMillis() - start)));
         }
     }
-
 }

--- a/client/src/main/java/io/split/client/metrics/HttpMetrics.java
+++ b/client/src/main/java/io/split/client/metrics/HttpMetrics.java
@@ -29,7 +29,7 @@ public class HttpMetrics implements Metrics, DTOMetrics {
 
 
     public static HttpMetrics create(CloseableHttpClient client, URI root) throws URISyntaxException {
-        return new HttpMetrics(client, new URIBuilder(root).build());
+        return new HttpMetrics(client, Utils.appendPath(root, "/api/metrics/time"));
     }
 
 
@@ -49,7 +49,7 @@ public class HttpMetrics implements Metrics, DTOMetrics {
         }
 
         try {
-            post(new URIBuilder(_target).setPath("/api/metrics/time").build(), dto);
+            post(_target, dto);
         } catch (Throwable t) {
             _log.warn("Exception when posting metric" + dto, t);
         }

--- a/client/src/main/java/io/split/client/metrics/HttpMetrics.java
+++ b/client/src/main/java/io/split/client/metrics/HttpMetrics.java
@@ -30,7 +30,7 @@ public class HttpMetrics implements Metrics, DTOMetrics {
 
 
     public static HttpMetrics create(CloseableHttpClient client, URI root) throws URISyntaxException {
-        return new HttpMetrics(client, Utils.appendPath(root, "/api/metrics/time"));
+        return new HttpMetrics(client, Utils.appendPath(root, "api/metrics/time"));
     }
 
 

--- a/client/src/main/java/io/split/client/metrics/HttpMetrics.java
+++ b/client/src/main/java/io/split/client/metrics/HttpMetrics.java
@@ -1,5 +1,6 @@
 package io.split.client.metrics;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.split.client.dtos.Counter;
 import io.split.client.dtos.Latency;
@@ -124,4 +125,8 @@ public class HttpMetrics implements Metrics, DTOMetrics {
         }
     }
 
+    @VisibleForTesting
+    URI getTarget() {
+        return _target;
+    }
 }

--- a/client/src/test/java/io/split/client/EventsClientImplTest.java
+++ b/client/src/test/java/io/split/client/EventsClientImplTest.java
@@ -1,0 +1,44 @@
+package io.split.client;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class EventsClientImplTest {
+    @Test
+    public void testDefaultURL() throws URISyntaxException {
+        URI rootTarget = URI.create("https://api.split.io");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        EventClientImpl fetcher = EventClientImpl.create(httpClient, rootTarget, 5, 5, 5);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://api.split.io/api/events/bulk")));
+    }
+
+    @Test
+    public void testCustomURLNoPathNoBackslash() throws URISyntaxException {
+        URI rootTarget = URI.create("https://kubernetesturl.com/split");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        EventClientImpl fetcher = EventClientImpl.create(httpClient, rootTarget, 5, 5, 5);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/events/bulk")));
+    }
+
+    @Test
+    public void testCustomURLAppendingPath() throws URISyntaxException {
+        URI rootTarget = URI.create("https://kubernetesturl.com/split/");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        EventClientImpl fetcher = EventClientImpl.create(httpClient, rootTarget, 5, 5, 5);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/events/bulk")));
+    }
+
+    @Test
+    public void testCustomURLAppendingPathNoBackslash() throws URISyntaxException {
+        URI rootTarget = URI.create("https://kubernetesturl.com/split");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        EventClientImpl fetcher = EventClientImpl.create(httpClient, rootTarget, 5, 5, 5);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/events/bulk")));
+    }
+}

--- a/client/src/test/java/io/split/client/EventsClientImplTest.java
+++ b/client/src/test/java/io/split/client/EventsClientImplTest.java
@@ -20,10 +20,10 @@ public class EventsClientImplTest {
 
     @Test
     public void testCustomURLNoPathNoBackslash() throws URISyntaxException {
-        URI rootTarget = URI.create("https://kubernetesturl.com/split");
+        URI rootTarget = URI.create("https://kubernetesturl.com/");
         CloseableHttpClient httpClient = HttpClients.custom().build();
         EventClientImpl fetcher = EventClientImpl.create(httpClient, rootTarget, 5, 5, 5);
-        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/events/bulk")));
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/api/events/bulk")));
     }
 
     @Test

--- a/client/src/test/java/io/split/client/EventsClientImplTest.java
+++ b/client/src/test/java/io/split/client/EventsClientImplTest.java
@@ -20,7 +20,7 @@ public class EventsClientImplTest {
 
     @Test
     public void testCustomURLNoPathNoBackslash() throws URISyntaxException {
-        URI rootTarget = URI.create("https://kubernetesturl.com/");
+        URI rootTarget = URI.create("https://kubernetesturl.com");
         CloseableHttpClient httpClient = HttpClients.custom().build();
         EventClientImpl fetcher = EventClientImpl.create(httpClient, rootTarget, 5, 5, 5);
         Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/api/events/bulk")));

--- a/client/src/test/java/io/split/client/impressions/HttpImpressionsSenderTest.java
+++ b/client/src/test/java/io/split/client/impressions/HttpImpressionsSenderTest.java
@@ -21,10 +21,10 @@ public class HttpImpressionsSenderTest {
 
     @Test
     public void testCustomURLNoPathNoBackslash() throws URISyntaxException {
-        URI rootTarget = URI.create("https://kubernetesturl.com/split");
+        URI rootTarget = URI.create("https://kubernetesturl.com/");
         CloseableHttpClient httpClient = HttpClients.custom().build();
         HttpImpressionsSender fetcher = HttpImpressionsSender.create(httpClient, rootTarget);
-        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/testImpressions/bulk")));
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/api/testImpressions/bulk")));
     }
 
     @Test

--- a/client/src/test/java/io/split/client/impressions/HttpImpressionsSenderTest.java
+++ b/client/src/test/java/io/split/client/impressions/HttpImpressionsSenderTest.java
@@ -21,7 +21,7 @@ public class HttpImpressionsSenderTest {
 
     @Test
     public void testCustomURLNoPathNoBackslash() throws URISyntaxException {
-        URI rootTarget = URI.create("https://kubernetesturl.com/");
+        URI rootTarget = URI.create("https://kubernetesturl.com");
         CloseableHttpClient httpClient = HttpClients.custom().build();
         HttpImpressionsSender fetcher = HttpImpressionsSender.create(httpClient, rootTarget);
         Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/api/testImpressions/bulk")));

--- a/client/src/test/java/io/split/client/impressions/HttpImpressionsSenderTest.java
+++ b/client/src/test/java/io/split/client/impressions/HttpImpressionsSenderTest.java
@@ -1,0 +1,46 @@
+package io.split.client.impressions;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class HttpImpressionsSenderTest {
+
+    @Test
+    public void testDefaultURL() throws URISyntaxException {
+        URI rootTarget = URI.create("https://api.split.io");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        HttpImpressionsSender fetcher = HttpImpressionsSender.create(httpClient, rootTarget);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://api.split.io/api/testImpressions/bulk")));
+    }
+
+    @Test
+    public void testCustomURLNoPathNoBackslash() throws URISyntaxException {
+        URI rootTarget = URI.create("https://kubernetesturl.com/split");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        HttpImpressionsSender fetcher = HttpImpressionsSender.create(httpClient, rootTarget);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/testImpressions/bulk")));
+    }
+
+    @Test
+    public void testCustomURLAppendingPath() throws URISyntaxException {
+        URI rootTarget = URI.create("https://kubernetesturl.com/split/");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        HttpImpressionsSender fetcher = HttpImpressionsSender.create(httpClient, rootTarget);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/testImpressions/bulk")));
+    }
+
+    @Test
+    public void testCustomURLAppendingPathNoBackslash() throws URISyntaxException {
+        URI rootTarget = URI.create("https://kubernetesturl.com/split");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        HttpImpressionsSender fetcher = HttpImpressionsSender.create(httpClient, rootTarget);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/testImpressions/bulk")));
+    }
+
+}

--- a/client/src/test/java/io/split/client/metrics/HttpMetricsTest.java
+++ b/client/src/test/java/io/split/client/metrics/HttpMetricsTest.java
@@ -20,7 +20,7 @@ public class HttpMetricsTest {
 
     @Test
     public void testCustomURLNoPathNoBackslash() throws URISyntaxException {
-        URI rootTarget = URI.create("https://kubernetesturl.com/");
+        URI rootTarget = URI.create("https://kubernetesturl.com");
         CloseableHttpClient httpClient = HttpClients.custom().build();
         HttpMetrics fetcher = HttpMetrics.create(httpClient, rootTarget);
         Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/api/metrics/time")));

--- a/client/src/test/java/io/split/client/metrics/HttpMetricsTest.java
+++ b/client/src/test/java/io/split/client/metrics/HttpMetricsTest.java
@@ -1,0 +1,44 @@
+package io.split.client.metrics;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class HttpMetricsTest {
+    @Test
+    public void testDefaultURL() throws URISyntaxException {
+        URI rootTarget = URI.create("https://api.split.io");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        HttpMetrics fetcher = HttpMetrics.create(httpClient, rootTarget);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://api.split.io/api/metrics/time")));
+    }
+
+    @Test
+    public void testCustomURLNoPathNoBackslash() throws URISyntaxException {
+        URI rootTarget = URI.create("https://kubernetesturl.com/split");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        HttpMetrics fetcher = HttpMetrics.create(httpClient, rootTarget);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/metrics/time")));
+    }
+
+    @Test
+    public void testCustomURLAppendingPath() throws URISyntaxException {
+        URI rootTarget = URI.create("https://kubernetesturl.com/split/");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        HttpMetrics fetcher = HttpMetrics.create(httpClient, rootTarget);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/metrics/time")));
+    }
+
+    @Test
+    public void testCustomURLAppendingPathNoBackslash() throws URISyntaxException {
+        URI rootTarget = URI.create("https://kubernetesturl.com/split");
+        CloseableHttpClient httpClient = HttpClients.custom().build();
+        HttpMetrics fetcher = HttpMetrics.create(httpClient, rootTarget);
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/metrics/time")));
+    }
+}

--- a/client/src/test/java/io/split/client/metrics/HttpMetricsTest.java
+++ b/client/src/test/java/io/split/client/metrics/HttpMetricsTest.java
@@ -20,10 +20,10 @@ public class HttpMetricsTest {
 
     @Test
     public void testCustomURLNoPathNoBackslash() throws URISyntaxException {
-        URI rootTarget = URI.create("https://kubernetesturl.com/split");
+        URI rootTarget = URI.create("https://kubernetesturl.com/");
         CloseableHttpClient httpClient = HttpClients.custom().build();
         HttpMetrics fetcher = HttpMetrics.create(httpClient, rootTarget);
-        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/split/api/metrics/time")));
+        Assert.assertThat(fetcher.getTarget().toString(), Matchers.is(Matchers.equalTo("https://kubernetesturl.com/api/metrics/time")));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.split.client</groupId>
     <artifactId>java-client-parent</artifactId>
-    <version>2.3.2</version>
+    <version>2.3.3-rc</version>
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
Previous PR did not take into account Impressions/Metrics/Events. Since our Synchronizer was set with base, it passed all our testing harnesses. Will work on using a Synchronizer with a full path