### PR TITLE
fix race condition with loading events

### DIFF
--- a/client/CHANGES.txt
+++ b/client/CHANGES.txt
@@ -1,4 +1,7 @@
 CHANGES
+3.0.4
+- Fix potential race condition when segment wait for readiness before they are registered to the readiness gates
+
 3.0.3
 - Expose param to increase thread pool size for segments
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.4</version>
     </parent>
     <artifactId>java-client</artifactId>
     <packaging>jar</packaging>
@@ -154,6 +154,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.21</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client/src/main/java/io/split/engine/SDKReadinessGates.java
+++ b/client/src/main/java/io/split/engine/SDKReadinessGates.java
@@ -3,7 +3,6 @@ package io.split.engine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -64,31 +63,6 @@ public class SDKReadinessGates {
     }
 
     /**
-     * Registers the segments that the SDK should download before it is ready.
-     * This method should be called right after the first successful download
-     * of split definitions.
-     * <p/>
-     * Note that if this method is called in subsequent fetches of splits,
-     * it will return false; meaning any segments used in new splits
-     * will not be able to block the SDK from being marked as complete.
-     *
-     * @param segmentNames
-     * @return true if the segments were registered, false otherwise.
-     * @throws InterruptedException
-     */
-    public boolean registerSegments(Collection<String> segmentNames) throws InterruptedException {
-        if (segmentNames.isEmpty() || areSplitsReady(0L)) {
-            return false;
-        }
-
-        for (String segmentName : segmentNames) {
-            registerSegment(segmentName);
-        }
-
-        return true;
-    }
-
-    /**
      * Registers a segment that the SDK should download before it is ready.
      * This method should be called right after the first successful download
      * of split definitions.
@@ -97,7 +71,7 @@ public class SDKReadinessGates {
      * it will return false; meaning any segments used in new splits
      * will not be able to block the SDK from being marked as complete.
      *
-     * @param segmentName
+     * @param segmentName the segment to register
      * @return true if the segments were registered, false otherwise.
      * @throws InterruptedException
      */

--- a/client/src/main/java/io/split/engine/experiments/RefreshableSplitFetcher.java
+++ b/client/src/main/java/io/split/engine/experiments/RefreshableSplitFetcher.java
@@ -190,7 +190,6 @@ public class RefreshableSplitFetcher implements SplitFetcher, Runnable {
             _changeNumber.set(change.till);
         }
 
-        _gates.registerSegments(segmentsInUse);
     }
 
     private List<String> collectSegmentsInUse(Split split) {

--- a/client/src/main/java/io/split/engine/segments/RefreshableSegment.java
+++ b/client/src/main/java/io/split/engine/segments/RefreshableSegment.java
@@ -71,6 +71,7 @@ public class RefreshableSegment implements Runnable, Segment {
     @Override
     public void run() {
         try {
+            _gates.registerSegment(_segmentName);
             while (true) {
                 long start = _changeNumber.get();
                 runWithoutExceptionHandling();

--- a/client/src/test/java/io/split/engine/experiments/RefreshableSplitFetcherTest.java
+++ b/client/src/test/java/io/split/engine/experiments/RefreshableSplitFetcherTest.java
@@ -187,7 +187,7 @@ public class RefreshableSplitFetcherTest {
         RefreshableSplitFetcher fetcher = new RefreshableSplitFetcher(experimentChangeFetcher, new SplitParser(segmentFetcher), gates, startingChangeNumber);
 
         // execute the fetcher for a little bit.
-        executeWaitAndTerminate(fetcher, 1, 3, TimeUnit.SECONDS);
+        executeWaitAndTerminate(fetcher, 1, 5, TimeUnit.SECONDS);
 
         assertThat(experimentChangeFetcher.lastAdded(), is(greaterThan(startingChangeNumber)));
         assertThat(fetcher.changeNumber(), is(equalTo(experimentChangeFetcher.lastAdded())));

--- a/client/src/test/java/io/split/engine/segments/RefreshableSegmentTest.java
+++ b/client/src/test/java/io/split/engine/segments/RefreshableSegmentTest.java
@@ -1,6 +1,5 @@
 package io.split.engine.segments;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.split.engine.SDKReadinessGates;
 import org.junit.Test;
@@ -43,7 +42,7 @@ public class RefreshableSegmentTest {
     public void works_when_there_are_no_changes() throws InterruptedException {
         long startingChangeNumber = -1L;
         SDKReadinessGates gates = new SDKReadinessGates();
-        gates.registerSegments(Lists.newArrayList("foo"));
+        gates.registerSegment("foo");
 
         OneChangeOnlySegmentChangeFetcher segmentChangeFetcher = new OneChangeOnlySegmentChangeFetcher();
         RefreshableSegment fetcher = new RefreshableSegment("foo", segmentChangeFetcher, startingChangeNumber, gates);
@@ -85,7 +84,7 @@ public class RefreshableSegmentTest {
     private void works(long startingChangeNumber) throws InterruptedException {
         SDKReadinessGates gates = new SDKReadinessGates();
         String segmentName = "foo";
-        gates.registerSegments(Lists.newArrayList(segmentName));
+        gates.registerSegment(segmentName);
 
         TheseManyChangesSegmentChangeFetcher segmentChangeFetcher = new TheseManyChangesSegmentChangeFetcher(2);
         RefreshableSegment fetcher = new RefreshableSegment(segmentName, segmentChangeFetcher, startingChangeNumber, gates);

--- a/client/src/test/resources/log4j.properties
+++ b/client/src/test/resources/log4j.properties
@@ -9,7 +9,7 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
 # Print only messages of level WARN or above in the package com.foo.
 log4j.logger.org.glassfish.jersey=WARN
 
-log4j.logger.split.org.apache.http=info
-log4j.logger.org.apache.http=info
-log4j.logger.split.org.apache.http.wire=info
-log4j.logger.io.split.engine.experiments.RefreshableSplitFetcher=debug
+#log4j.logger.split.org.apache.http=info
+#log4j.logger.org.apache.http=info
+#log4j.logger.split.org.apache.http.wire=info
+#log4j.logger.io.split.engine.experiments.RefreshableSplitFetcher=debug

--- a/client/src/test/resources/log4j.properties
+++ b/client/src/test/resources/log4j.properties
@@ -1,0 +1,15 @@
+log4j.rootLogger=info, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+# Pattern to output the caller's file name and line number.
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
+
+# Print only messages of level WARN or above in the package com.foo.
+log4j.logger.org.glassfish.jersey=WARN
+
+log4j.logger.split.org.apache.http=info
+log4j.logger.org.apache.http=info
+log4j.logger.split.org.apache.http.wire=info
+log4j.logger.io.split.engine.experiments.RefreshableSplitFetcher=debug

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.split.client</groupId>
     <artifactId>java-client-parent</artifactId>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.4</version>
     </parent>
 
     <artifactId>java-client-testing</artifactId>


### PR DESCRIPTION
``` INFO [split-segmentFetcher-0] (SDKReadinessGates.java:110) - Registered segment: demo_orgs
 INFO [split-splitFetcher-0] (SDKReadinessGates.java:62) - splits are ready
 INFO [split-segmentFetcher-0] (RefreshableSegment.java:135) - demo_orgs added keys: [2dfcc270-aacc-11e8-a8d2-xxxxxxxxxxx, 7479b040-aa14-11e8-91c4-xxxxxxxxxxx, 745622b0-aa14-11e8-91c4-12bc02531368... 5 others]
 INFO [split-segmentFetcher-0] (SDKReadinessGates.java:130) - demo_orgs segment is ready```