### PR TITLE
Add support for optional timestamp parameter when tracking an event.

### DIFF
--- a/client/CHANGES.txt
+++ b/client/CHANGES.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+3.2.3
+- Add support for optional timestamp parameter when tracking an event.
+
 3.2.2
 - log warn and not error when Split doesn't exist in the environment
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
     </parent>
     <artifactId>java-client</artifactId>
     <packaging>jar</packaging>

--- a/client/src/main/java/io/split/client/AlwaysReturnControlSplitClient.java
+++ b/client/src/main/java/io/split/client/AlwaysReturnControlSplitClient.java
@@ -68,7 +68,27 @@ public class AlwaysReturnControlSplitClient implements SplitClient {
     }
 
     @Override
+    public boolean track(String key, String trafficType, String eventType, long timestamp) {
+        return false;
+    }
+
+    @Override
     public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties) {
+        return false;
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, long timestamp) {
+        return false;
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, Map<String, Object> properties, long timestamp) {
+        return false;
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties, long timestamp) {
         return false;
     }
 

--- a/client/src/main/java/io/split/client/LocalhostSplitClient.java
+++ b/client/src/main/java/io/split/client/LocalhostSplitClient.java
@@ -118,7 +118,27 @@ public final class LocalhostSplitClient implements SplitClient {
     }
 
     @Override
+    public boolean track(String key, String trafficType, String eventType, long timestamp) {
+        return false;
+    }
+
+    @Override
     public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties) {
+        return false;
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, long timestamp) {
+        return false;
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, Map<String, Object> properties, long timestamp) {
+        return false;
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties, long timestamp) {
         return false;
     }
 

--- a/client/src/main/java/io/split/client/LocalhostSplitClientAndFactory.java
+++ b/client/src/main/java/io/split/client/LocalhostSplitClientAndFactory.java
@@ -92,8 +92,28 @@ public final class LocalhostSplitClientAndFactory implements SplitClient {
     }
 
     @Override
+    public boolean track(String key, String trafficType, String eventType, long timestamp) {
+        return _splitClient.track(key, trafficType, eventType, timestamp);
+    }
+
+    @Override
     public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties) {
         return _splitClient.track(key, trafficType, eventType, value, properties);
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, long timestamp) {
+        return _splitClient.track(key, trafficType, eventType, value, timestamp);
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, Map<String, Object> properties, long timestamp) {
+        return _splitClient.track(key, trafficType, eventType, properties, timestamp);
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties, long timestamp) {
+        return _splitClient.track(key, trafficType, eventType, value, properties, timestamp);
     }
 
     @Override

--- a/client/src/main/java/io/split/client/SplitClient.java
+++ b/client/src/main/java/io/split/client/SplitClient.java
@@ -184,11 +184,26 @@ public interface SplitClient {
      * @param key the identifier of the entity
      * @param trafficType the type of the event
      * @param eventType the type of the event
-     * @param value the value of the event
+     * @param properties a map of key value pairs that can be used to filter your metrics
      *
      * @return true if the track was successful, false otherwise
      */
     boolean track(String key, String trafficType, String eventType, Map<String, Object> properties);
+
+    /**
+     * Enqueue a new event to be sent to split data collection services
+     *
+     * Example:
+     *      client.track("account, "Split Software", "checkout", 1562791206372L)
+     *
+     * @param key the identifier of the entity
+     * @param trafficType the type of the event
+     * @param eventType the type of the event
+     * @param timestamp the timestamp in milliseconds since midnight, January 1, 1970 UTC
+     *
+     * @return true if the track was successful, false otherwise
+     */
+    boolean track(String key, String trafficType, String eventType, long timestamp);
 
     /**
      * Enqueue a new event to be sent to split data collection services
@@ -200,10 +215,60 @@ public interface SplitClient {
      * @param trafficType the type of the event
      * @param eventType the type of the event
      * @param value the value of the event
+     * @param properties a map of key value pairs that can be used to filter your metrics
      *
      * @return true if the track was successful, false otherwise
      */
     boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties);
+
+    /**
+     * Enqueue a new event to be sent to split data collection services
+     *
+     * Example:
+     *      client.track(“account”, “Split Software”, “checkout”, 123, 1562791206372L)
+     *
+     * @param key the identifier of the entity
+     * @param trafficType the type of the event
+     * @param eventType the type of the event
+     * @param value the value of the event
+     * @param timestamp the timestamp in milliseconds since midnight, January 1, 1970 UTC
+     *
+     * @return true if the track was successful, false otherwise
+     */
+    boolean track(String key, String trafficType, String eventType, double value, long timestamp);
+
+    /**
+     * Enqueue a new event to be sent to split data collection services
+     *
+     * Example:
+     *      client.track(“account”, “Split Software”, “checkout”, Collections.singletonMap("age", 23), 1562791206372L)
+     *
+     * @param key the identifier of the entity
+     * @param trafficType the type of the event
+     * @param eventType the type of the event
+     * @param properties a map of key value pairs that can be used to filter your metrics
+     * @param timestamp the timestamp in milliseconds since midnight, January 1, 1970 UTC
+     *
+     * @return true if the track was successful, false otherwise
+     */
+    boolean track(String key, String trafficType, String eventType, Map<String, Object> properties, long timestamp);
+
+    /**
+     * Enqueue a new event to be sent to split data collection services
+     *
+     * Example:
+     *      client.track(“account”, “Split Software”, “checkout”, 123, Collections.singletonMap("age", 23), 1562791206372L)
+     *
+     * @param key the identifier of the entity
+     * @param trafficType the type of the event
+     * @param eventType the type of the event
+     * @param value the value of the event
+     * @param properties a map of key value pairs that can be used to filter your metrics
+     * @param timestamp the timestamp in milliseconds since midnight, January 1, 1970 UTC
+     *
+     * @return true if the track was successful, false otherwise
+     */
+    boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties, long timestamp);
 
 
     /**

--- a/client/src/main/java/io/split/client/SplitClientImpl.java
+++ b/client/src/main/java/io/split/client/SplitClientImpl.java
@@ -344,9 +344,41 @@ public final class SplitClientImpl implements SplitClient {
     }
 
     @Override
+    public boolean track(String key, String trafficType, String eventType, long timestamp) {
+        Event event = createEvent(key, trafficType, eventType);
+        event.timestamp = timestamp;
+        return track(event);
+    }
+
+    @Override
     public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties) {
         Event event = createEvent(key, trafficType, eventType);
         event.properties = new HashMap<>(properties);
+        event.value = value;
+        return track(event);
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, long timestamp) {
+        Event event = createEvent(key, trafficType, eventType);
+        event.timestamp = timestamp;
+        event.value = value;
+        return track(event);
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, Map<String, Object> properties, long timestamp) {
+        Event event = createEvent(key, trafficType, eventType);
+        event.properties = new HashMap<>(properties);
+        event.timestamp = timestamp;
+        return track(event);
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties, long timestamp) {
+        Event event = createEvent(key, trafficType, eventType);
+        event.properties = new HashMap<>(properties);
+        event.timestamp = timestamp;
         event.value = value;
         return track(event);
     }

--- a/client/src/test/java/io/split/client/SplitClientImplTest.java
+++ b/client/src/test/java/io/split/client/SplitClientImplTest.java
@@ -1069,7 +1069,22 @@ public class SplitClientImplTest {
         Assert.assertThat(captured.properties.size(), org.hamcrest.Matchers.is(1));
         Assert.assertThat((Integer) captured.properties.get("ok_property"), org.hamcrest.Matchers.is(123));
 
-
+        properties.clear();
+        Mockito.reset(eventClientMock);
+        Mockito.when(eventClientMock.track((Event) Mockito.any(), Mockito.anyInt())).thenReturn(true);
+        properties.put("ok_property", 123);
+        Assert.assertThat(client.track("key1", "user", "purchase", 123, properties, 1562791206372L),
+                org.hamcrest.Matchers.is(true));
+        eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventClientMock).track(eventArgumentCaptor.capture(), Mockito.anyInt());
+        captured = eventArgumentCaptor.getValue();
+        Assert.assertThat(captured.timestamp, org.hamcrest.Matchers.is(1562791206372L));
+        Assert.assertThat(captured.value, org.hamcrest.Matchers.is(123.0));
+        Assert.assertThat(captured.trafficTypeName,org.hamcrest.Matchers.is("user"));
+        Assert.assertThat(captured.eventTypeId,org.hamcrest.Matchers.is("purchase"));
+        Assert.assertThat(captured.key,org.hamcrest.Matchers.is("key1"));
+        Assert.assertThat(captured.properties.size(), org.hamcrest.Matchers.is(1));
+        Assert.assertThat((Integer) captured.properties.get("ok_property"), org.hamcrest.Matchers.is(123));
 
         properties.clear();
         Mockito.reset(eventClientMock);

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.split.client</groupId>
     <artifactId>java-client-parent</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3</version>
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
     </parent>
 
     <artifactId>java-client-testing</artifactId>

--- a/testing/src/main/java/io/split/client/testing/SplitClientForTest.java
+++ b/testing/src/main/java/io/split/client/testing/SplitClientForTest.java
@@ -92,7 +92,27 @@ public class SplitClientForTest implements SplitClient {
     }
 
     @Override
+    public boolean track(String key, String trafficType, String eventType, long timestamp) {
+        return false;
+    }
+
+    @Override
     public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties) {
+        return false;
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, long timestamp) {
+        return false;
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, Map<String, Object> properties, long timestamp) {
+        return false;
+    }
+
+    @Override
+    public boolean track(String key, String trafficType, String eventType, double value, Map<String, Object> properties, long timestamp) {
         return false;
     }
 


### PR DESCRIPTION
We noticed while using the Java SDK that timestamps were being set automatically to `System.currentTimeMillis()` which may or may not be UTC, depending on the server's settings. This can lead to incorrect metrics being reported by Split in the portal. Additionally, if there's some problem in our pipeline, there's no way to replay events and have them show up at the proper time. This ends up mattering a lot sometimes. So, instead of re-implementing all our logic to use the HTTP Admin API, it made a lot more sense to just open a pull request against the Java SDK.

This PR adds support for timestamps to the Split Client's `.track(...)` functions. It also updates the test suite in order to assert the behavior and increments the client's patch version (though perhaps it should have been a minor version increment instead?).