### PR TITLE
Switch to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ deploy:
     skip_cleanup: true
     script: mvn -DskipTests sonar:sonar
     on:
-      branch: development
+      branch: test/ubuntu-trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ deploy:
     skip_cleanup: true
     script: mvn -DskipTests sonar:sonar
     on:
-      branch: test/ubuntu-trusty
+      branch: development

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
-dist: precise
+dist: trusty
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8
+
+cache:
+  directories:
+    - $HOME/.m2
 
 before_script:
   - cp .travis.settings.xml ${HOME}/.m2/settings.xml
 
 script:
-  - mvn -Dhttps.protocols=TLSv1.2 clean install
+  - mvn clean install
 
 deploy:
   - provider: script
     skip_cleanup: true
-    script: mvn --quiet sonar:sonar -DskipTests
+    script: mvn -DskipTests sonar:sonar
     on:
       branch: development


### PR DESCRIPTION
Using JDK 1.7 implies Maven2 and the Sonar plugin is deprecated (it won't work with our Sonar server).

Since releases are being made with JDK 1.8 anyway, let's run the tests with the same version.