### PR TITLE
Updated README to bump up the Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This SDK is designed to work with Split, the platform for controlled rollouts, s
 [![Twitter Follow](https://img.shields.io/twitter/follow/splitsoftware.svg?style=social&label=Follow&maxAge=1529000)](https://twitter.com/intent/follow?screen_name=splitsoftware)
 
 ## Compatibility
-This SDK is compatible with Java 6 and higher.
+This SDK is compatible with Java 8 and higher.
 
 ## Getting started
 Below is a simple example that describes the instantiation and most basic usage of our SDK:


### PR DESCRIPTION
Minimum supported Java version was 6. Bumping that to 8. 
This will make your multi-catch in the README consistent, as well as your documentation: https://help.split.io/hc/en-us/articles/360020405151-Java-SDK