### PR TITLE
Do not embed JUnit / Set scope to provided on testing client

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -13,6 +13,7 @@
     <packaging>jar</packaging>
     <name>Java Client For Testing</name>
     <description>Testing suite for Java SDK for Split</description>
+
     <dependencies>
         <dependency>
             <groupId>io.split.client</groupId>
@@ -22,6 +23,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
[Snyk](https://snyk.io/) is now present in the build process at Salesforce projects.
While checking the vulnerabilities reports, I notice an older version of JUnit coming from the Split testing jar.
Yes, we were using an outdated version of the Split SDK, and upgrading it to the latest fixed it. 

But to avoid this kind of issue in the future, I would like to suggest this change.
IMO, JUnit should be provided by the consumer, not by the library, and will likely be already present in the project.

Thank you!