### PR TITLE
Readme & pom fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This SDK is designed to work with Split, the platform for controlled rollouts, s
 [![Twitter Follow](https://img.shields.io/twitter/follow/splitsoftware.svg?style=social&label=Follow&maxAge=1529000)](https://twitter.com/intent/follow?screen_name=splitsoftware)
 
 ## Compatibility
-This SDK is compatible with Java 6 and higher.
+This SDK is compatible with Java 8 and higher.
 
 ## Getting started
 Below is a simple example that describes the instantiation and most basic usage of our SDK:

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -19,8 +19,8 @@
                 <version>3.3</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <!-- Shade dependencies to avoid conflicts with other customer's libs -->

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <!-- Release plugin -->


### PR DESCRIPTION
If you attempt to build with an earlier jdk, you get:

```
java: warning: source release 8 requires target release 1.8
```

because of the source and target definitions in the pom.xml.

This also updates pom.xml's to use the properties defined in the parent for source and target