### PR TITLE
NOC-608: Adding extra Host header for Fastly

### DIFF
--- a/client/src/main/java/io/split/client/HttpSplitChangeFetcher.java
+++ b/client/src/main/java/io/split/client/HttpSplitChangeFetcher.java
@@ -1,6 +1,7 @@
 package io.split.client;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import io.split.client.dtos.SplitChange;
 import io.split.client.utils.Json;
 import io.split.client.utils.Utils;
@@ -40,6 +41,8 @@ public final class HttpSplitChangeFetcher implements SplitChangeFetcher {
     private static final String HEADER_FASTLY_DEBUG_NAME = "Fastly-Debug";
     private static final String HEADER_FASTLY_DEBUG_VALUE = "1";
 
+    private static final String HEADER_FASTLY_HOST = "Host";
+
     private final CloseableHttpClient _client;
     private final URI _target;
     private final Metrics _metrics;
@@ -61,7 +64,7 @@ public final class HttpSplitChangeFetcher implements SplitChangeFetcher {
 
     long makeRandomTill() {
 
-        return (-1)*(long)Math.floor(Math.random()*(Math.pow(2, 63)));
+        return (-1) * (long) Math.floor(Math.random() * (Math.pow(2, 63)));
     }
 
     @Override
@@ -79,12 +82,16 @@ public final class HttpSplitChangeFetcher implements SplitChangeFetcher {
             URI uri = uriBuilder.build();
 
             HttpGet request = new HttpGet(uri);
-            if(options.cacheControlHeadersEnabled()) {
+            if (options.cacheControlHeadersEnabled()) {
                 request.setHeader(HEADER_CACHE_CONTROL_NAME, HEADER_CACHE_CONTROL_VALUE);
             }
 
             if (options.fastlyDebugHeaderEnabled()) {
                 request.addHeader(HEADER_FASTLY_DEBUG_NAME, HEADER_FASTLY_DEBUG_VALUE);
+            }
+
+            if (!Strings.isNullOrEmpty(options.hostHeader())) {
+                request.setHeader(HEADER_FASTLY_HOST, options.hostHeader());
             }
 
             response = _client.execute(request);

--- a/client/src/main/java/io/split/client/SplitClientConfig.java
+++ b/client/src/main/java/io/split/client/SplitClientConfig.java
@@ -50,6 +50,7 @@ public class SplitClientConfig {
     private final int _onDemandFetchMaxRetries;
     private final int _failedAttemptsBeforeLogging;
     private final boolean _cdnDebugLogging;
+    private final String _hostHeader;
 
     // Proxy configs
     private final HttpHost _proxy;
@@ -97,7 +98,8 @@ public class SplitClientConfig {
                               int onDemandFetchRetryDelayMs,
                               int onDemandFetchMaxRetries,
                               int failedAttemptsBeforeLogging,
-                              boolean cdnDebugLogging) {
+                              boolean cdnDebugLogging,
+                              String hostHeader) {
         _endpoint = endpoint;
         _eventsEndpoint = eventsEndpoint;
         _featuresRefreshRate = pollForFeatureChangesEveryNSeconds;
@@ -132,6 +134,7 @@ public class SplitClientConfig {
         _onDemandFetchMaxRetries = onDemandFetchMaxRetries;
         _failedAttemptsBeforeLogging = failedAttemptsBeforeLogging;
         _cdnDebugLogging = cdnDebugLogging;
+        _hostHeader = hostHeader;
 
         Properties props = new Properties();
         try {
@@ -268,6 +271,8 @@ public class SplitClientConfig {
 
     public boolean cdnDebugLogging() { return _cdnDebugLogging; }
 
+    public String hostHeader() { return _hostHeader; }
+
 
     public static final class Builder {
 
@@ -308,6 +313,7 @@ public class SplitClientConfig {
         private final int _onDemandFetchMaxRetries = 10;
         private final int _failedAttemptsBeforeLogging = 10;
         private final boolean _cdnDebugLogging = true;
+        private String _hostHeader = null;
 
         public Builder() {
         }
@@ -699,6 +705,11 @@ public class SplitClientConfig {
             return this;
         }
 
+        public Builder hostHeader(String hostHeader) {
+            _hostHeader = hostHeader;
+            return this;
+        }
+
         public SplitClientConfig build() {
             if (_featuresRefreshRate < 5 ) {
                 throw new IllegalArgumentException("featuresRefreshRate must be >= 5: " + _featuresRefreshRate);
@@ -810,7 +821,8 @@ public class SplitClientConfig {
                     _onDemandFetchRetryDelayMs,
                     _onDemandFetchMaxRetries,
                     _failedAttemptsBeforeLogging,
-                    _cdnDebugLogging);
+                    _cdnDebugLogging,
+                    _hostHeader);
         }
     }
 }

--- a/client/src/main/java/io/split/client/SplitFactoryImpl.java
+++ b/client/src/main/java/io/split/client/SplitFactoryImpl.java
@@ -126,7 +126,7 @@ public class SplitFactoryImpl implements SplitFactory {
         _segmentSynchronizationTaskImp = buildSegments(config);
 
         // SplitFetcher
-        _splitFetcher = buildSplitFetcher();
+        _splitFetcher = buildSplitFetcher(config);
 
         // SplitSynchronizationTask
         _splitSynchronizationTask = new SplitSynchronizationTask(_splitFetcher,
@@ -161,7 +161,8 @@ public class SplitFactoryImpl implements SplitFactory {
                 config.streamingRetryDelay(),
                 config.streamingFetchMaxRetries(),
                 config.failedAttemptsBeforeLogging(),
-                config.cdnDebugLogging());
+                config.cdnDebugLogging(),
+                config.hostHeader());
         _syncManager.start();
 
         // Evaluator
@@ -333,11 +334,11 @@ public class SplitFactoryImpl implements SplitFactory {
                 _segmentCache);
     }
 
-    private SplitFetcher buildSplitFetcher() throws URISyntaxException {
+    private SplitFetcher buildSplitFetcher(SplitClientConfig config) throws URISyntaxException {
         SplitChangeFetcher splitChangeFetcher = HttpSplitChangeFetcher.create(_httpclient, _rootTarget, _unCachedFireAndForget);
         SplitParser splitParser = new SplitParser(_segmentSynchronizationTaskImp, _segmentCache);
 
-        return new SplitFetcherImp(splitChangeFetcher, splitParser, _gates, _splitCache);
+        return new SplitFetcherImp(splitChangeFetcher, splitParser, _gates, _splitCache, config);
     }
 
     private ImpressionsManagerImpl buildImpressionsManager(SplitClientConfig config) throws URISyntaxException {

--- a/client/src/main/java/io/split/client/SplitFactoryImpl.java
+++ b/client/src/main/java/io/split/client/SplitFactoryImpl.java
@@ -331,7 +331,8 @@ public class SplitFactoryImpl implements SplitFactory {
                 findPollingPeriod(RANDOM, config.segmentsRefreshRate()),
                 config.numThreadsForSegmentFetch(),
                 _gates,
-                _segmentCache);
+                _segmentCache,
+                config);
     }
 
     private SplitFetcher buildSplitFetcher(SplitClientConfig config) throws URISyntaxException {

--- a/client/src/main/java/io/split/engine/common/FetchOptions.java
+++ b/client/src/main/java/io/split/engine/common/FetchOptions.java
@@ -17,6 +17,7 @@ public class FetchOptions {
             _cacheControlHeaders = opts._cacheControlHeaders;
             _fastlyDebugHeader = opts._fastlyDebugHeader;
             _responseHeadersCallback = opts._responseHeadersCallback;
+            _hostHeader = opts._hostHeader;
         }
 
         public Builder cacheControlHeaders(boolean on) {
@@ -39,13 +40,19 @@ public class FetchOptions {
             return this;
         }
 
+        public Builder hostHeader(String hostHeader) {
+            _hostHeader = hostHeader;
+            return this;
+        }
+
         public FetchOptions build() {
-            return new FetchOptions(_cacheControlHeaders, _targetCN, _responseHeadersCallback, _fastlyDebugHeader);
+            return new FetchOptions(_cacheControlHeaders, _targetCN, _responseHeadersCallback, _fastlyDebugHeader, _hostHeader);
         }
 
         private long _targetCN = DEFAULT_TARGET_CHANGENUMBER;
         private boolean _cacheControlHeaders = false;
         private boolean _fastlyDebugHeader = false;
+        private String _hostHeader = null;
         private Function<Map<String, String>, Void> _responseHeadersCallback = null;
     }
 
@@ -61,6 +68,8 @@ public class FetchOptions {
 
     public boolean hasCustomCN() { return _targetCN != DEFAULT_TARGET_CHANGENUMBER; }
 
+    public String hostHeader() { return _hostHeader; }
+
     public void handleResponseHeaders(Map<String, String> headers) {
         if (Objects.isNull(_responseHeadersCallback) || Objects.isNull(headers)) {
             return;
@@ -71,11 +80,12 @@ public class FetchOptions {
     private FetchOptions(boolean cacheControlHeaders,
                          long targetCN,
                          Function<Map<String, String>, Void> responseHeadersCallback,
-                         boolean fastlyDebugHeader) {
+                         boolean fastlyDebugHeader, String hostHeader) {
         _cacheControlHeaders = cacheControlHeaders;
         _targetCN = targetCN;
         _responseHeadersCallback = responseHeadersCallback;
         _fastlyDebugHeader = fastlyDebugHeader;
+        _hostHeader = hostHeader;
     }
 
     @Override
@@ -89,16 +99,18 @@ public class FetchOptions {
         return Objects.equals(_cacheControlHeaders, other._cacheControlHeaders)
                 && Objects.equals(_fastlyDebugHeader, other._fastlyDebugHeader)
                 && Objects.equals(_responseHeadersCallback, other._responseHeadersCallback)
-                && Objects.equals(_targetCN, other._targetCN);
+                && Objects.equals(_targetCN, other._targetCN)
+                && Objects.equals(_hostHeader, other._hostHeader);
     }
 
     @Override
     public int hashCode() {
-        return com.google.common.base.Objects.hashCode(_cacheControlHeaders, _fastlyDebugHeader, _responseHeadersCallback, _targetCN);
+        return com.google.common.base.Objects.hashCode(_cacheControlHeaders, _fastlyDebugHeader, _responseHeadersCallback, _targetCN, _hostHeader);
     }
 
     private final boolean _cacheControlHeaders;
     private final boolean _fastlyDebugHeader;
     private final long _targetCN;
+    private final String _hostHeader;
     private final Function<Map<String, String>, Void> _responseHeadersCallback;
 }

--- a/client/src/main/java/io/split/engine/common/SyncManagerImp.java
+++ b/client/src/main/java/io/split/engine/common/SyncManagerImp.java
@@ -63,7 +63,8 @@ public class SyncManagerImp implements SyncManager {
                                        int streamingRetryDelay,
                                        int maxOnDemandFetchRetries,
                                        int failedAttemptsBeforeLogging,
-                                       boolean cdnDebugLogging) {
+                                       boolean cdnDebugLogging,
+                                       String hostHeader) {
         LinkedBlockingQueue<PushManager.Status> pushMessages = new LinkedBlockingQueue<>();
         Synchronizer synchronizer = new SynchronizerImp(splitSynchronizationTask,
                                                         splitFetcher,
@@ -73,7 +74,8 @@ public class SyncManagerImp implements SyncManager {
                                                         streamingRetryDelay,
                                                         maxOnDemandFetchRetries,
                                                         failedAttemptsBeforeLogging,
-                                                        cdnDebugLogging);
+                                                        cdnDebugLogging,
+                                                        hostHeader);
 
         PushManager pushManager = PushManagerImp.build(synchronizer,
                                                         streamingServiceUrl,

--- a/client/src/main/java/io/split/engine/common/SynchronizerImp.java
+++ b/client/src/main/java/io/split/engine/common/SynchronizerImp.java
@@ -75,7 +75,7 @@ public class SynchronizerImp implements Synchronizer {
         _syncAllScheduledExecutorService.schedule(() -> {
             FetchOptions fetchOptions = new FetchOptions.Builder().cacheControlHeaders(true).hostHeader(_hostHeader).build();
             _splitFetcher.fetchAll(fetchOptions);
-            _segmentSynchronizationTaskImp.fetchAll(false);
+            _segmentSynchronizationTaskImp.fetchAll(new FetchOptions.Builder(fetchOptions).cacheControlHeaders(false).build());
         }, 0, TimeUnit.SECONDS);
     }
 

--- a/client/src/main/java/io/split/engine/experiments/SplitFetcherImp.java
+++ b/client/src/main/java/io/split/engine/experiments/SplitFetcherImp.java
@@ -1,5 +1,6 @@
 package io.split.engine.experiments;
 
+import io.split.client.SplitClientConfig;
 import io.split.client.dtos.Split;
 import io.split.client.dtos.SplitChange;
 import io.split.client.dtos.Status;
@@ -24,6 +25,7 @@ public class SplitFetcherImp implements SplitFetcher {
     private final SplitChangeFetcher _splitChangeFetcher;
     private final SplitCache _splitCache;
     private final SDKReadinessGates _gates;
+    private final SplitClientConfig _config;
     private final Object _lock = new Object();
 
     /**
@@ -36,11 +38,12 @@ public class SplitFetcherImp implements SplitFetcher {
      * an ARCHIVED split is received, we know if we need to remove a traffic type from the multiset.
      */
 
-    public SplitFetcherImp(SplitChangeFetcher splitChangeFetcher, SplitParser parser, SDKReadinessGates gates, SplitCache splitCache) {
+    public SplitFetcherImp(SplitChangeFetcher splitChangeFetcher, SplitParser parser, SDKReadinessGates gates, SplitCache splitCache, SplitClientConfig config) {
         _splitChangeFetcher = checkNotNull(splitChangeFetcher);
         _parser = checkNotNull(parser);
         _gates = checkNotNull(gates);
         _splitCache = checkNotNull(splitCache);
+        _config = checkNotNull(config);
     }
 
     @Override
@@ -74,7 +77,7 @@ public class SplitFetcherImp implements SplitFetcher {
 
     @Override
     public void run() {
-        this.fetchAll(new FetchOptions.Builder().cacheControlHeaders(false).build());
+        this.fetchAll(new FetchOptions.Builder().cacheControlHeaders(false).hostHeader(_config.hostHeader()).build());
     }
 
     private void runWithoutExceptionHandling(FetchOptions options) throws InterruptedException {

--- a/client/src/main/java/io/split/engine/segments/SegmentFetcher.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentFetcher.java
@@ -11,7 +11,5 @@ public interface SegmentFetcher {
      */
     void fetch(FetchOptions opts);
 
-    void runWhitCacheHeader();
-
-    void fetchAll();
+    void fetchAll(FetchOptions opts);
 }

--- a/client/src/main/java/io/split/engine/segments/SegmentFetcherImp.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentFetcherImp.java
@@ -126,8 +126,8 @@ public class SegmentFetcherImp implements SegmentFetcher {
     }
 
     @Override
-    public void runWhitCacheHeader(){
-        this.fetchAndUpdate(new FetchOptions.Builder().cacheControlHeaders(true).build());
+    public void fetchAll(FetchOptions fetchOptions) {
+        this.fetchAndUpdate(fetchOptions);
     }
 
     /**
@@ -149,11 +149,4 @@ public class SegmentFetcherImp implements SegmentFetcher {
             }
         }
     }
-
-    @Override
-    public void fetchAll() {
-        this.fetchAndUpdate(new FetchOptions.Builder().build());
-    }
-
-
 }

--- a/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTask.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTask.java
@@ -1,5 +1,7 @@
 package io.split.engine.segments;
 
+import io.split.engine.common.FetchOptions;
+
 public interface SegmentSynchronizationTask extends Runnable {
     /**
      * initializes the segment
@@ -28,5 +30,5 @@ public interface SegmentSynchronizationTask extends Runnable {
      * fetch every Segment
      * @param addCacheHeader
      */
-    void fetchAll(boolean addCacheHeader);
+    void fetchAll(FetchOptions fetchOptions);
 }

--- a/client/src/test/java/io/split/engine/common/SynchronizerTest.java
+++ b/client/src/test/java/io/split/engine/common/SynchronizerTest.java
@@ -45,7 +45,7 @@ public class SynchronizerTest {
 
         Thread.sleep(100);
         Mockito.verify(_splitFetcher, Mockito.times(1)).fetchAll(new FetchOptions.Builder().cacheControlHeaders(true).build());
-        Mockito.verify(_segmentFetcher, Mockito.times(1)).fetchAll(true);
+        Mockito.verify(_segmentFetcher, Mockito.times(1)).fetchAll(new FetchOptions.Builder().cacheControlHeaders(false).build());
     }
 
     @Test

--- a/client/src/test/java/io/split/engine/common/SynchronizerTest.java
+++ b/client/src/test/java/io/split/engine/common/SynchronizerTest.java
@@ -36,7 +36,7 @@ public class SynchronizerTest {
         _splitCache = Mockito.mock(SplitCache.class);
         _segmentCache = Mockito.mock(SegmentCache.class);
 
-        _synchronizer = new SynchronizerImp(_refreshableSplitFetcherTask, _splitFetcher, _segmentFetcher, _splitCache, _segmentCache, 50, 10, 5, false);
+        _synchronizer = new SynchronizerImp(_refreshableSplitFetcherTask, _splitFetcher, _segmentFetcher, _splitCache, _segmentCache, 50, 10, 5, false, null);
     }
 
     @Test
@@ -94,7 +94,8 @@ public class SynchronizerTest {
                 50,
                 3,
                 1,
-                true);
+                true,
+                null);
 
         ArgumentCaptor<FetchOptions> optionsCaptor = ArgumentCaptor.forClass(FetchOptions.class);
         AtomicInteger calls = new AtomicInteger();
@@ -128,7 +129,8 @@ public class SynchronizerTest {
                 50,
                 3,
                 1,
-                true);
+                true,
+                null);
 
         ArgumentCaptor<FetchOptions> optionsCaptor = ArgumentCaptor.forClass(FetchOptions.class);
         AtomicInteger calls = new AtomicInteger();
@@ -185,7 +187,8 @@ public class SynchronizerTest {
                 50,
                 3,
                 1,
-                true);
+                true,
+                null);
 
         SegmentFetcher fetcher = Mockito.mock(SegmentFetcher.class);
         when(_segmentFetcher.getFetcher("someSegment")).thenReturn(fetcher);

--- a/client/src/test/java/io/split/engine/experiments/SplitFetcherTest.java
+++ b/client/src/test/java/io/split/engine/experiments/SplitFetcherTest.java
@@ -5,6 +5,7 @@ import io.split.cache.InMemoryCacheImp;
 import io.split.cache.SegmentCache;
 import io.split.cache.SegmentCacheInMemoryImpl;
 import io.split.cache.SplitCache;
+import io.split.client.SplitClientConfig;
 import io.split.client.dtos.*;
 import io.split.engine.ConditionsTestUtil;
 import io.split.engine.SDKReadinessGates;
@@ -63,7 +64,7 @@ public class SplitFetcherTest {
         SegmentChangeFetcher segmentChangeFetcher = Mockito.mock(SegmentChangeFetcher.class);
         SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1,10, gates, segmentCache);
         SplitCache cache = new InMemoryCacheImp(startingChangeNumber);
-        SplitFetcherImp fetcher = new SplitFetcherImp(splitChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), gates, cache);
+        SplitFetcherImp fetcher = new SplitFetcherImp(splitChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), gates, cache, SplitClientConfig.builder().build());
 
         // execute the fetcher for a little bit.
         executeWaitAndTerminate(fetcher, 1, 3, TimeUnit.SECONDS);
@@ -137,7 +138,7 @@ public class SplitFetcherTest {
         SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1,10, gates, segmentCache);
         segmentSynchronizationTask.startPeriodicFetching();
         SplitCache cache = new InMemoryCacheImp(-1);
-        SplitFetcherImp fetcher = new SplitFetcherImp(splitChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), new SDKReadinessGates(), cache);
+        SplitFetcherImp fetcher = new SplitFetcherImp(splitChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), new SDKReadinessGates(), cache, SplitClientConfig.builder().build());
 
         // execute the fetcher for a little bit.
         executeWaitAndTerminate(fetcher, 1, 5, TimeUnit.SECONDS);
@@ -159,7 +160,7 @@ public class SplitFetcherTest {
         SegmentChangeFetcher segmentChangeFetcher = mock(SegmentChangeFetcher.class);
         SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1,10, gates, segmentCache);
         segmentSynchronizationTask.startPeriodicFetching();
-        SplitFetcherImp fetcher = new SplitFetcherImp(splitChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), gates, cache);
+        SplitFetcherImp fetcher = new SplitFetcherImp(splitChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), gates, cache, SplitClientConfig.builder().build());
 
         // execute the fetcher for a little bit.
         executeWaitAndTerminate(fetcher, 1, 5, TimeUnit.SECONDS);
@@ -201,7 +202,7 @@ public class SplitFetcherTest {
         when(segmentChangeFetcher.fetch(anyString(), anyLong(), any())).thenReturn(segmentChange);
         SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1,10, gates, segmentCache);
         segmentSynchronizationTask.startPeriodicFetching();
-        SplitFetcherImp fetcher = new SplitFetcherImp(experimentChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), gates, cache);
+        SplitFetcherImp fetcher = new SplitFetcherImp(experimentChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), gates, cache, SplitClientConfig.builder().build());
 
         // execute the fetcher for a little bit.
         executeWaitAndTerminate(fetcher, 1, 5, TimeUnit.SECONDS);
@@ -229,7 +230,7 @@ public class SplitFetcherTest {
         SplitParser mockParser = new SplitParser(segmentSynchronizationTaskMock, segmentCacheMock);
         SDKReadinessGates mockGates = Mockito.mock(SDKReadinessGates.class);
         SplitCache mockCache = new InMemoryCacheImp();
-        SplitFetcherImp fetcher = new SplitFetcherImp(mockFetcher, mockParser, mockGates, mockCache);
+        SplitFetcherImp fetcher = new SplitFetcherImp(mockFetcher, mockParser, mockGates, mockCache, SplitClientConfig.builder().build());
 
 
         SplitChange response1 = new SplitChange();

--- a/client/src/test/java/io/split/engine/experiments/SplitFetcherTest.java
+++ b/client/src/test/java/io/split/engine/experiments/SplitFetcherTest.java
@@ -62,7 +62,7 @@ public class SplitFetcherTest {
         SDKReadinessGates gates = new SDKReadinessGates();
         SegmentCache segmentCache = new SegmentCacheInMemoryImpl();
         SegmentChangeFetcher segmentChangeFetcher = Mockito.mock(SegmentChangeFetcher.class);
-        SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1,10, gates, segmentCache);
+        SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1,10, gates, segmentCache, SplitClientConfig.builder().build());
         SplitCache cache = new InMemoryCacheImp(startingChangeNumber);
         SplitFetcherImp fetcher = new SplitFetcherImp(splitChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), gates, cache, SplitClientConfig.builder().build());
 
@@ -135,7 +135,7 @@ public class SplitFetcherTest {
         SegmentCache segmentCache = new SegmentCacheInMemoryImpl();
 
         SegmentChangeFetcher segmentChangeFetcher = mock(SegmentChangeFetcher.class);
-        SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1,10, gates, segmentCache);
+        SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1,10, gates, segmentCache, SplitClientConfig.builder().build());
         segmentSynchronizationTask.startPeriodicFetching();
         SplitCache cache = new InMemoryCacheImp(-1);
         SplitFetcherImp fetcher = new SplitFetcherImp(splitChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), new SDKReadinessGates(), cache, SplitClientConfig.builder().build());
@@ -158,7 +158,7 @@ public class SplitFetcherTest {
         SegmentCache segmentCache = new SegmentCacheInMemoryImpl();
 
         SegmentChangeFetcher segmentChangeFetcher = mock(SegmentChangeFetcher.class);
-        SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1,10, gates, segmentCache);
+        SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1,10, gates, segmentCache, SplitClientConfig.builder().build());
         segmentSynchronizationTask.startPeriodicFetching();
         SplitFetcherImp fetcher = new SplitFetcherImp(splitChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), gates, cache, SplitClientConfig.builder().build());
 
@@ -200,7 +200,7 @@ public class SplitFetcherTest {
         SegmentChangeFetcher segmentChangeFetcher = mock(SegmentChangeFetcher.class);
         SegmentChange segmentChange = getSegmentChange(0L, 0L, segmentName);
         when(segmentChangeFetcher.fetch(anyString(), anyLong(), any())).thenReturn(segmentChange);
-        SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1,10, gates, segmentCache);
+        SegmentSynchronizationTask segmentSynchronizationTask = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1,10, gates, segmentCache, SplitClientConfig.builder().build());
         segmentSynchronizationTask.startPeriodicFetching();
         SplitFetcherImp fetcher = new SplitFetcherImp(experimentChangeFetcher, new SplitParser(segmentSynchronizationTask, segmentCache), gates, cache, SplitClientConfig.builder().build());
 

--- a/client/src/test/java/io/split/engine/experiments/SplitParserTest.java
+++ b/client/src/test/java/io/split/engine/experiments/SplitParserTest.java
@@ -3,6 +3,7 @@ package io.split.engine.experiments;
 import com.google.common.collect.Lists;
 import io.split.cache.SegmentCache;
 import io.split.cache.SegmentCacheInMemoryImpl;
+import io.split.client.SplitClientConfig;
 import io.split.client.dtos.*;
 import io.split.engine.ConditionsTestUtil;
 import io.split.engine.SDKReadinessGates;

--- a/client/src/test/java/io/split/engine/experiments/SplitParserTest.java
+++ b/client/src/test/java/io/split/engine/experiments/SplitParserTest.java
@@ -61,7 +61,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeSalesPeople = getSegmentChange(-1L, -1L, SALES_PEOPLE);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee).thenReturn(segmentChangeSalesPeople);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
 
 
@@ -100,7 +100,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeSalesPeople = getSegmentChange(-1L, -1L, SALES_PEOPLE);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee).thenReturn(segmentChangeSalesPeople);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
 
@@ -144,7 +144,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeSalesPeople = getSegmentChange(-1L, -1L, SALES_PEOPLE);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee).thenReturn(segmentChangeSalesPeople);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
 
@@ -183,7 +183,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeEmployee = getSegmentChange(-1L, -1L, EMPLOYEES);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
 
@@ -213,7 +213,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeSalesPeople = getSegmentChange(-1L, -1L, SALES_PEOPLE);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee).thenReturn(segmentChangeSalesPeople);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
 
@@ -259,7 +259,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeSalesPeople = getSegmentChange(-1L, -1L, SALES_PEOPLE);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee).thenReturn(segmentChangeSalesPeople);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
 
@@ -298,7 +298,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeSalesPeople = getSegmentChange(-1L, -1L, SALES_PEOPLE);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee).thenReturn(segmentChangeSalesPeople);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
 
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
@@ -337,7 +337,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeSalesPeople = getSegmentChange(-1L, -1L, SALES_PEOPLE);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee).thenReturn(segmentChangeSalesPeople);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
 
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
@@ -376,7 +376,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeSalesPeople = getSegmentChange(-1L, -1L, SALES_PEOPLE);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee).thenReturn(segmentChangeSalesPeople);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
 
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
@@ -553,7 +553,7 @@ public class SplitParserTest {
         SegmentChange segmentChangeSalesPeople = getSegmentChange(-1L, -1L, SALES_PEOPLE);
         Mockito.when(segmentChangeFetcher.fetch(Mockito.anyString(), Mockito.anyLong(), Mockito.any())).thenReturn(segmentChangeEmployee).thenReturn(segmentChangeSalesPeople);
 
-        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache);
+        SegmentSynchronizationTask segmentFetcher = new SegmentSynchronizationTaskImp(segmentChangeFetcher,1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
         SplitParser parser = new SplitParser(segmentFetcher, segmentCache);
 

--- a/client/src/test/java/io/split/engine/segments/SegmentFetcherImpTest.java
+++ b/client/src/test/java/io/split/engine/segments/SegmentFetcherImpTest.java
@@ -67,7 +67,7 @@ public class SegmentFetcherImpTest {
 
         // execute the fetcher for a little bit.
         ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-        scheduledExecutorService.scheduleWithFixedDelay(fetcher::fetchAll, 0L, 100, TimeUnit.MICROSECONDS);
+        scheduledExecutorService.scheduleWithFixedDelay(() -> fetcher.fetchAll(new FetchOptions.Builder().build()), 0L, 100, TimeUnit.MICROSECONDS);
         Thread.currentThread().sleep(5 * 100);
 
         scheduledExecutorService.shutdown();
@@ -108,7 +108,7 @@ public class SegmentFetcherImpTest {
 
         // execute the fetcher for a little bit.
         ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-        scheduledExecutorService.scheduleWithFixedDelay(fetcher::fetchAll, 0L, Integer.MAX_VALUE, TimeUnit.SECONDS);
+        scheduledExecutorService.scheduleWithFixedDelay(() -> fetcher.fetchAll(new FetchOptions.Builder().build()), 0L, Integer.MAX_VALUE, TimeUnit.SECONDS);
         Thread.currentThread().sleep(5 * 100);
 
         scheduledExecutorService.shutdown();

--- a/client/src/test/java/io/split/engine/segments/SegmentSynchronizationTaskImpTest.java
+++ b/client/src/test/java/io/split/engine/segments/SegmentSynchronizationTaskImpTest.java
@@ -1,5 +1,6 @@
 package io.split.engine.segments;
 
+import io.split.client.SplitClientConfig;
 import io.split.engine.SDKReadinessGates;
 import io.split.cache.SegmentCache;
 import org.junit.Before;
@@ -40,7 +41,7 @@ public class SegmentSynchronizationTaskImpTest {
         SegmentCache segmentCache = Mockito.mock(SegmentCache.class);
 
         SegmentChangeFetcher segmentChangeFetcher = Mockito.mock(SegmentChangeFetcher.class);
-        final SegmentSynchronizationTaskImp fetchers = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1L, 1, gates, segmentCache);
+        final SegmentSynchronizationTaskImp fetchers = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1L, 1, gates, segmentCache, SplitClientConfig.builder().build());
 
 
         // create two tasks that will separately call segment and make sure


### PR DESCRIPTION
Adding extra Host header for Segment & Split Changes. In that way we can set the SDK to directly call Fastly DCA.

```java
SplitClientConfig config = SplitClientConfig.builder()
                .endpoint("https://cache-dca17775.hosts.fastly.net", "https://events.split-stage.io")
                .setBlockUntilReadyTimeout(60000)
                .hostHeader("sdk.split-stage.io")
                .build();
```                