### PR TITLE
Shade all client dependencies except slf4j-api

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -43,10 +43,15 @@
                                     <include>io.split.client:*</include>
                                     <include>io.split.schemas:*</include>
                                     <include>io.codigo.grammar:*</include>
-                                    <include>org.apache.httpcomponents:httpclient</include>
-                                    <include>org.apache.httpcomponents:httpcore</include>
-                                    <include>com.google.code.gson:gson</include>
-                                    <include>com.google.guava:guava</include>
+                                    <include>org.apache.httpcomponents.*</include>
+                                    <include>com.google.*</include>
+                                    <include>org.yaml:snakeyaml:*</include>
+
+                                    <!-- Transitive dependency of guava -->
+                                    <include>org.checkerframework:*</include>
+
+                                    <!-- Transitive dependency of httpclient5. Package name is org.apache.commons -->
+                                    <include>commons-codec:*</include>
                                 </includes>
                             </artifactSet>
                             <transformers>
@@ -55,12 +60,20 @@
                             </transformers>
                             <relocations>
                                 <relocation>
-                                    <pattern>org.apache.http</pattern>
-                                    <shadedPattern>split.org.apache.http</shadedPattern>
+                                    <pattern>org.apache</pattern>
+                                    <shadedPattern>split.org.apache</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.google</pattern>
                                     <shadedPattern>split.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.yaml</pattern>
+                                    <shadedPattern>split.org.yaml</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.checkerframework</pattern>
+                                    <shadedPattern>split.org.checkerframework</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>


### PR DESCRIPTION
Include and relocate *all* direct and transitive dependencies except for `slf4j-api` in the `java-client` uber jar.

For validation, the `dependency-reduced-pom.xml` has changed in the following way:

#### Before
```xml
  <dependencies>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>failureaccess</artifactId>
      <version>1.0.1</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>listenablefuture</artifactId>
      <version>9999.0-empty-to-avoid-conflict-with-guava</version>
      <scope>compile</scope>
    </dependency>
    ...
```

#### After
```xml
  <dependencies>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.25</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
```

Relates to #241