### PR TITLE
Fix not relocated packages

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -61,8 +61,16 @@
                             </transformers>
                             <relocations>
                                 <relocation>
-                                    <pattern>org.apache.http</pattern>
-                                    <shadedPattern>split.org.apache.http</shadedPattern>
+                                    <pattern>org.apache</pattern>
+                                    <shadedPattern>split.org.apache</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.checkerframework</pattern>
+                                    <shadedPattern>split.org.checkerframework</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.yaml.snakeyaml</pattern>
+                                    <shadedPattern>split.org.yaml.snakeyaml</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.google</pattern>


### PR DESCRIPTION
Hi, 

I added relocations of transitive dependencies shadowed in java-client.jar, because my team has a problem with duplicated classes for:
`org.apache.httpcomponents.client5:httpclient5`

I also added other relocations for `org.checkerframework` and `org.yaml.snakeyaml` to avoid potential further problems