### PR TITLE
[SDKS-5858] Update the destroy in SplitFactoryImplementation

### DIFF
--- a/client/src/main/java/io/split/client/SplitClientConfig.java
+++ b/client/src/main/java/io/split/client/SplitClientConfig.java
@@ -58,7 +58,8 @@ public class SplitClientConfig {
     private final int _onDemandFetchRetryDelayMs;
     private final int _onDemandFetchMaxRetries;
     private final int _failedAttemptsBeforeLogging;
-    private final int _uniqueKeysRefreshRate;
+    private final int _uniqueKeysRefreshRateInMemory;
+    private final int _uniqueKeysRefreshRateRedis;
     private static int _filterUniqueKeysRefreshRate;
     private final boolean _cdnDebugLogging;
     private final OperationMode _operationMode;
@@ -119,7 +120,8 @@ public class SplitClientConfig {
                               long validateAfterInactivityInMillis,
                               CustomStorageWrapper customStorageWrapper,
                               StorageMode storageMode,
-                              int uniqueKeysRefreshRate,
+                              int uniqueKeysRefreshRateInMemory,
+                              int uniqueKeysRefreshRateRedis,
                               int filterUniqueKeysRefreshRate) {
         _endpoint = endpoint;
         _eventsEndpoint = eventsEndpoint;
@@ -153,7 +155,8 @@ public class SplitClientConfig {
         _streamingServiceURL = streamingServiceURL;
         _telemetryURL = telemetryURL;
         _telemetryRefreshRate = telemetryRefreshRate;
-        _uniqueKeysRefreshRate = uniqueKeysRefreshRate;
+        _uniqueKeysRefreshRateInMemory = uniqueKeysRefreshRateInMemory;
+        _uniqueKeysRefreshRateRedis = uniqueKeysRefreshRateRedis;
         _filterUniqueKeysRefreshRate = filterUniqueKeysRefreshRate;
         _onDemandFetchRetryDelayMs = onDemandFetchRetryDelayMs;
         _onDemandFetchMaxRetries = onDemandFetchMaxRetries;
@@ -201,8 +204,11 @@ public class SplitClientConfig {
         return _impressionsRefreshRate;
     }
 
-    public int uniqueKeysRefreshRate() {
-        return _uniqueKeysRefreshRate;
+    public int uniqueKeysRefreshRateInMemory() {
+        return _uniqueKeysRefreshRateInMemory;
+    }
+    public int uniqueKeysRefreshRateRedis() {
+        return _uniqueKeysRefreshRateRedis;
     }
     public static int filterUniqueKeysRefreshRate() {
         return _filterUniqueKeysRefreshRate;
@@ -362,7 +368,8 @@ public class SplitClientConfig {
         private String _streamingServiceURL = STREAMING_ENDPOINT;
         private String _telemetryURl = TELEMETRY_ENDPOINT;
         private int _telemetryRefreshRate = 3600;
-        private final int _uniqueKeysRefreshRate = 900;
+        private final int _uniqueKeysRefreshRateInMemory = 900;
+        private final int _uniqueKeysRefreshRateRedis = 300;
         private final int _filterUniqueKeysRefreshRate = 86400;
         private int _onDemandFetchRetryDelayMs = 50;
         private final int _onDemandFetchMaxRetries = 10;
@@ -953,7 +960,8 @@ public class SplitClientConfig {
                     _validateAfterInactivityInMillis,
                     _customStorageWrapper,
                     _storageMode,
-                    _uniqueKeysRefreshRate,
+                    _uniqueKeysRefreshRateInMemory,
+                    _uniqueKeysRefreshRateRedis,
                     _filterUniqueKeysRefreshRate);
         }
     }

--- a/client/src/main/java/io/split/client/impressions/ImpressionsManagerImpl.java
+++ b/client/src/main/java/io/split/client/impressions/ImpressionsManagerImpl.java
@@ -9,6 +9,7 @@ import io.split.client.impressions.strategy.ProcessImpressionDebug;
 import io.split.client.impressions.strategy.ProcessImpressionNone;
 import io.split.client.impressions.strategy.ProcessImpressionOptimized;
 import io.split.client.impressions.strategy.ProcessImpressionStrategy;
+import io.split.storages.enums.OperationMode;
 import io.split.telemetry.domain.enums.ImpressionsDataTypeEnum;
 import io.split.telemetry.storage.TelemetryRuntimeProducer;
 import io.split.telemetry.synchronizer.TelemetrySynchronizer;
@@ -110,7 +111,9 @@ public class ImpressionsManagerImpl implements ImpressionsManager, Closeable {
             case NONE:
                 _scheduler.scheduleAtFixedRate(this::sendImpressionCounters, COUNT_INITIAL_DELAY_SECONDS, COUNT_REFRESH_RATE_SECONDS, TimeUnit.SECONDS);
                 counter = new ImpressionCounter();
-                uniqueKeysTracker = new UniqueKeysTrackerImp(telemetrySynchronizer, _config.uniqueKeysRefreshRate(), _config.filterUniqueKeysRefreshRate());
+                int uniqueKeysRefreshRate = _config.operationMode().equals(OperationMode.STANDALONE) ? _config.uniqueKeysRefreshRateInMemory()
+                        : _config.uniqueKeysRefreshRateRedis();
+                uniqueKeysTracker = new UniqueKeysTrackerImp(telemetrySynchronizer, uniqueKeysRefreshRate, _config.filterUniqueKeysRefreshRate());
                 processImpressionStrategy = new ProcessImpressionNone(_listener!=null, uniqueKeysTracker, counter);
                 break;
         }


### PR DESCRIPTION
- Update the destroy in SplitFactoryImplementation
- Update the close method in ImpressionManager to close the UniqueKeysTracker, and send the unique keys and counters.
- Add uniqueKeys refresh rate for Redis 