### PR TITLE
[SDKS-6048] Avoid count when the previous time calculated is 0 or null

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>4.4.6-rc3</version>
+        <version>4.4.6-rc6</version>
     </parent>
     <artifactId>java-client</artifactId>
     <packaging>jar</packaging>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>io.split.client</groupId>
             <artifactId>pluggable-storage</artifactId>
-            <version>1.0.1-rc6</version>
+            <version>2.0.0-rc1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/client/src/main/java/io/split/client/impressions/strategy/ProcessImpressionOptimized.java
+++ b/client/src/main/java/io/split/client/impressions/strategy/ProcessImpressionOptimized.java
@@ -32,7 +32,9 @@ public class ProcessImpressionOptimized implements ProcessImpressionStrategy{
         List<Impression> impressionsToQueue = new ArrayList<>();
         for(Impression impression : impressions) {
             impression = impression.withPreviousTime(_impressionObserver.testAndSet(impression));
-            _impressionCounter.inc(impression.split(), impression.time(), 1);
+            if(!Objects.isNull(impression.pt()) && impression.pt() != 0){
+                _impressionCounter.inc(impression.split(), impression.time(), 1);
+            }
             if(shouldntQueueImpression(impression)) {
                 continue;
             }

--- a/client/src/main/java/io/split/engine/common/SynchronizerImp.java
+++ b/client/src/main/java/io/split/engine/common/SynchronizerImp.java
@@ -260,6 +260,6 @@ public class SynchronizerImp implements Synchronizer {
 
     private void forceRefreshSegment(String segmentName){
         SegmentFetcher segmentFetcher = _segmentSynchronizationTaskImp.getFetcher(segmentName);
-        segmentFetcher.fetchAll();
+        segmentFetcher.fetchFromTheBeginning();
     }
 }

--- a/client/src/main/java/io/split/engine/common/SynchronizerImp.java
+++ b/client/src/main/java/io/split/engine/common/SynchronizerImp.java
@@ -260,6 +260,6 @@ public class SynchronizerImp implements Synchronizer {
 
     private void forceRefreshSegment(String segmentName){
         SegmentFetcher segmentFetcher = _segmentSynchronizationTaskImp.getFetcher(segmentName);
-        segmentFetcher.fetchFromTheBeginning();
+        segmentFetcher.fetch(new FetchOptions.Builder().build());
     }
 }

--- a/client/src/main/java/io/split/engine/segments/SegmentFetcher.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentFetcher.java
@@ -13,5 +13,5 @@ public interface SegmentFetcher {
 
     boolean runWhitCacheHeader();
 
-    void fetchAll();
+    void fetchFromTheBeginning();
 }

--- a/client/src/main/java/io/split/engine/segments/SegmentFetcher.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentFetcher.java
@@ -12,6 +12,4 @@ public interface SegmentFetcher {
     void fetch(FetchOptions opts);
 
     boolean runWhitCacheHeader();
-
-    void fetchFromTheBeginning();
 }

--- a/client/src/main/java/io/split/engine/segments/SegmentFetcherImp.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentFetcherImp.java
@@ -156,7 +156,7 @@ public class SegmentFetcherImp implements SegmentFetcher {
     }
 
     @Override
-    public void fetchAll() {
+    public void fetchFromTheBeginning() {
         this.fetchAndUpdate(new FetchOptions.Builder().build());
     }
 }

--- a/client/src/main/java/io/split/engine/segments/SegmentFetcherImp.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentFetcherImp.java
@@ -39,7 +39,7 @@ public class SegmentFetcherImp implements SegmentFetcher {
     @Override
     public void fetch(FetchOptions opts){
         try {
-            callLoopRun(opts);
+            fetchUntil(opts);
         } catch (Throwable t) {
             _log.error("RefreshableSegmentFetcher failed: " + t.getMessage());
             if (_log.isDebugEnabled()) {
@@ -115,7 +115,7 @@ public class SegmentFetcherImp implements SegmentFetcher {
     }
 
     @VisibleForTesting
-    void callLoopRun(FetchOptions opts){
+    void fetchUntil(FetchOptions opts){
         final long INITIAL_CN = _segmentCacheProducer.getChangeNumber(_segmentName);
         while (true) {
             long start = _segmentCacheProducer.getChangeNumber(_segmentName);
@@ -143,7 +143,7 @@ public class SegmentFetcherImp implements SegmentFetcher {
     boolean fetchAndUpdate(FetchOptions opts) {
         try {
             // Do this again in case the previous call errored out.
-            callLoopRun(opts);
+            fetchUntil(opts);
             return true;
 
         } catch (Throwable t) {
@@ -153,10 +153,5 @@ public class SegmentFetcherImp implements SegmentFetcher {
             }
             return false;
         }
-    }
-
-    @Override
-    public void fetchFromTheBeginning() {
-        this.fetchAndUpdate(new FetchOptions.Builder().build());
     }
 }

--- a/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTaskImp.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTaskImp.java
@@ -3,11 +3,8 @@ package io.split.engine.segments;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.split.engine.SDKReadinessGates;
-import io.split.engine.experiments.ParsedSplit;
-import io.split.engine.matchers.UserDefinedSegmentMatcher;
 import io.split.storages.SegmentCacheProducer;
 import io.split.storages.SplitCacheConsumer;
-import io.split.storages.memory.InMemoryCacheImp;
 import io.split.telemetry.storage.TelemetryRuntimeProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,10 +12,8 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -95,7 +90,7 @@ public class SegmentSynchronizationTaskImp implements SegmentSynchronizationTask
             segment = new SegmentFetcherImp(segmentName, _segmentChangeFetcher, _gates, _segmentCacheProducer, _telemetryRuntimeProducer);
 
             if (_running.get()) {
-                _scheduledExecutorService.submit(segment::fetchAll);
+                _scheduledExecutorService.submit(segment::fetchFromTheBeginning);
             }
 
             _segmentFetchers.putIfAbsent(segmentName, segment);
@@ -165,7 +160,7 @@ public class SegmentSynchronizationTaskImp implements SegmentSynchronizationTask
                 continue;
             }
 
-            _scheduledExecutorService.submit(fetcher::fetchAll);
+            _scheduledExecutorService.submit(fetcher::fetchFromTheBeginning);
         }
     }
 

--- a/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTaskImp.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTaskImp.java
@@ -3,6 +3,7 @@ package io.split.engine.segments;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.split.engine.SDKReadinessGates;
+import io.split.engine.common.FetchOptions;
 import io.split.storages.SegmentCacheProducer;
 import io.split.storages.SplitCacheConsumer;
 import io.split.telemetry.storage.TelemetryRuntimeProducer;
@@ -90,7 +91,8 @@ public class SegmentSynchronizationTaskImp implements SegmentSynchronizationTask
             segment = new SegmentFetcherImp(segmentName, _segmentChangeFetcher, _gates, _segmentCacheProducer, _telemetryRuntimeProducer);
 
             if (_running.get()) {
-                _scheduledExecutorService.submit(segment::fetchFromTheBeginning);
+                SegmentFetcher finalSegment = segment;
+                _scheduledExecutorService.submit(() -> finalSegment.fetch(new FetchOptions.Builder().build()));
             }
 
             _segmentFetchers.putIfAbsent(segmentName, segment);
@@ -160,7 +162,7 @@ public class SegmentSynchronizationTaskImp implements SegmentSynchronizationTask
                 continue;
             }
 
-            _scheduledExecutorService.submit(fetcher::fetchFromTheBeginning);
+            _scheduledExecutorService.submit(() -> fetcher.fetch(new FetchOptions.Builder().build()));
         }
     }
 

--- a/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTaskImp.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTaskImp.java
@@ -88,13 +88,13 @@ public class SegmentSynchronizationTaskImp implements SegmentSynchronizationTask
                 return;
             }
 
-            SegmentFetcher finalSegment = new SegmentFetcherImp(segmentName, _segmentChangeFetcher, _gates, _segmentCacheProducer, _telemetryRuntimeProducer);
+            SegmentFetcher newSegment = new SegmentFetcherImp(segmentName, _segmentChangeFetcher, _gates, _segmentCacheProducer, _telemetryRuntimeProducer);
 
             if (_running.get()) {
-                _scheduledExecutorService.submit(() -> finalSegment.fetch(new FetchOptions.Builder().build()));
+                _scheduledExecutorService.submit(() -> newSegment.fetch(new FetchOptions.Builder().build()));
             }
 
-            _segmentFetchers.putIfAbsent(segmentName, finalSegment);
+            _segmentFetchers.putIfAbsent(segmentName, newSegment);
         }
     }
 

--- a/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTaskImp.java
+++ b/client/src/main/java/io/split/engine/segments/SegmentSynchronizationTaskImp.java
@@ -88,14 +88,13 @@ public class SegmentSynchronizationTaskImp implements SegmentSynchronizationTask
                 return;
             }
 
-            segment = new SegmentFetcherImp(segmentName, _segmentChangeFetcher, _gates, _segmentCacheProducer, _telemetryRuntimeProducer);
+            SegmentFetcher finalSegment = new SegmentFetcherImp(segmentName, _segmentChangeFetcher, _gates, _segmentCacheProducer, _telemetryRuntimeProducer);
 
             if (_running.get()) {
-                SegmentFetcher finalSegment = segment;
                 _scheduledExecutorService.submit(() -> finalSegment.fetch(new FetchOptions.Builder().build()));
             }
 
-            _segmentFetchers.putIfAbsent(segmentName, segment);
+            _segmentFetchers.putIfAbsent(segmentName, finalSegment);
         }
     }
 

--- a/client/src/test/java/io/split/client/impressions/strategy/ProcessImpressionOptimizedTest.java
+++ b/client/src/test/java/io/split/client/impressions/strategy/ProcessImpressionOptimizedTest.java
@@ -42,7 +42,7 @@ public class ProcessImpressionOptimizedTest {
 
         Assert.assertEquals(2,impressionsResult1.getImpressionsToQueue().size());
         Assert.assertEquals(3,impressionsResult1.getImpressionsToListener().size());
-        Assert.assertEquals(2, counter.popAll().size());
+        Assert.assertEquals(1, counter.popAll().size());
     }
 
     @Test
@@ -64,6 +64,6 @@ public class ProcessImpressionOptimizedTest {
         ImpressionsResult impressionsResult1 = processImpressionOptimized.process(impressions);
         Assert.assertEquals(2,impressionsResult1.getImpressionsToQueue().size());
         Assert.assertNull(impressionsResult1.getImpressionsToListener());
-        Assert.assertEquals(2, counter.popAll().size());
+        Assert.assertEquals(1, counter.popAll().size());
     }
 }

--- a/client/src/test/java/io/split/engine/segments/SegmentFetcherImpTest.java
+++ b/client/src/test/java/io/split/engine/segments/SegmentFetcherImpTest.java
@@ -24,10 +24,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 /**
@@ -65,7 +63,7 @@ public class SegmentFetcherImpTest {
 
         // execute the fetcher for a little bit.
         ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-        scheduledExecutorService.scheduleWithFixedDelay(fetcher::fetchFromTheBeginning, 0L, 100, TimeUnit.MICROSECONDS);
+        scheduledExecutorService.scheduleWithFixedDelay(() -> fetcher.fetch(new FetchOptions.Builder().build()), 0L, 100, TimeUnit.MICROSECONDS);
         Thread.currentThread().sleep(5 * 100);
 
         scheduledExecutorService.shutdown();
@@ -104,7 +102,7 @@ public class SegmentFetcherImpTest {
 
         // execute the fetcher for a little bit.
         ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-        scheduledExecutorService.scheduleWithFixedDelay(fetcher::fetchFromTheBeginning, 0L, Integer.MAX_VALUE, TimeUnit.SECONDS);
+        scheduledExecutorService.scheduleWithFixedDelay(() -> fetcher.fetch(new FetchOptions.Builder().build()), 0L, Integer.MAX_VALUE, TimeUnit.SECONDS);
         Thread.currentThread().sleep(5 * 100);
 
         scheduledExecutorService.shutdown();

--- a/client/src/test/java/io/split/engine/segments/SegmentFetcherImpTest.java
+++ b/client/src/test/java/io/split/engine/segments/SegmentFetcherImpTest.java
@@ -65,7 +65,7 @@ public class SegmentFetcherImpTest {
 
         // execute the fetcher for a little bit.
         ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-        scheduledExecutorService.scheduleWithFixedDelay(fetcher::fetchAll, 0L, 100, TimeUnit.MICROSECONDS);
+        scheduledExecutorService.scheduleWithFixedDelay(fetcher::fetchFromTheBeginning, 0L, 100, TimeUnit.MICROSECONDS);
         Thread.currentThread().sleep(5 * 100);
 
         scheduledExecutorService.shutdown();
@@ -104,7 +104,7 @@ public class SegmentFetcherImpTest {
 
         // execute the fetcher for a little bit.
         ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-        scheduledExecutorService.scheduleWithFixedDelay(fetcher::fetchAll, 0L, Integer.MAX_VALUE, TimeUnit.SECONDS);
+        scheduledExecutorService.scheduleWithFixedDelay(fetcher::fetchFromTheBeginning, 0L, Integer.MAX_VALUE, TimeUnit.SECONDS);
         Thread.currentThread().sleep(5 * 100);
 
         scheduledExecutorService.shutdown();

--- a/client/src/test/java/io/split/engine/segments/SegmentSynchronizationTaskImpTest.java
+++ b/client/src/test/java/io/split/engine/segments/SegmentSynchronizationTaskImpTest.java
@@ -97,10 +97,10 @@ public class SegmentSynchronizationTaskImpTest {
         _segmentFetchers.put("SF", segmentFetcher);
         final SegmentSynchronizationTaskImp fetchers = new SegmentSynchronizationTaskImp(segmentChangeFetcher, 1L, 1,
                 gates, segmentCacheProducer, TELEMETRY_STORAGE, Mockito.mock(SplitCacheConsumer.class));
-        Mockito.doNothing().when(segmentFetcher).callLoopRun(Mockito.anyObject());
+        Mockito.doNothing().when(segmentFetcher).fetchUntil(Mockito.anyObject());
         Mockito.when(segmentFetcher.runWhitCacheHeader()).thenReturn(false);
         Mockito.when(segmentFetcher.fetchAndUpdate(Mockito.anyObject())).thenReturn(false);
-        Mockito.doNothing().when(segmentFetcher).callLoopRun(Mockito.anyObject());
+        Mockito.doNothing().when(segmentFetcher).fetchUntil(Mockito.anyObject());
 
         // Before executing, we'll update the map of segmentFecthers via reflection.
         Field segmentFetchersForced = SegmentSynchronizationTaskImp.class.getDeclaredField("_segmentFetchers");
@@ -132,7 +132,7 @@ public class SegmentSynchronizationTaskImpTest {
         modifiersField.setAccessible(true);
         modifiersField.setInt(segmentFetchersForced, segmentFetchersForced.getModifiers() & ~Modifier.FINAL);
         segmentFetchersForced.set(fetchers, _segmentFetchers);
-        Mockito.doNothing().when(segmentFetcher).callLoopRun(Mockito.anyObject());
+        Mockito.doNothing().when(segmentFetcher).fetchUntil(Mockito.anyObject());
         Mockito.when(segmentFetcher.runWhitCacheHeader()).thenReturn(true);
         Mockito.when(segmentFetcher.fetchAndUpdate(Mockito.anyObject())).thenReturn(true);
         boolean fetch = fetchers.fetchAllSynchronous();

--- a/pluggable-storage/pom.xml
+++ b/pluggable-storage/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <artifactId>java-client-parent</artifactId>
         <groupId>io.split.client</groupId>
-        <version>4.4.6-rc3</version>
+        <version>4.4.6-rc6</version>
     </parent>
 
-    <version>1.0.1-rc6</version>
+    <version>2.0.0-rc1</version>
     <artifactId>pluggable-storage</artifactId>
     <packaging>jar</packaging>
     <name>Package for Pluggable Storage</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.split.client</groupId>
     <artifactId>java-client-parent</artifactId>
-    <version>4.4.6-rc3</version>
+    <version>4.4.6-rc6</version>
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/redis-wrapper/pom.xml
+++ b/redis-wrapper/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <artifactId>java-client-parent</artifactId>
         <groupId>io.split.client</groupId>
-        <version>4.4.6-rc3</version>
+        <version>4.4.6-rc6</version>
     </parent>
     <artifactId>redis-wrapper</artifactId>
-    <version>1.0.2-rc5</version>
+    <version>1.0.2-rc8</version>
     <packaging>jar</packaging>
     <name>Package for Redis Wrapper Implementation</name>
     <description>Implements Redis Pluggable Storage</description>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.split.client</groupId>
             <artifactId>pluggable-storage</artifactId>
-            <version>1.0.1-rc6</version>
+            <version>2.0.0-rc1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>io.split.client</groupId>
             <artifactId>pluggable-storage</artifactId>
-            <version>1.0.1-rc6</version>
+            <version>2.0.0-rc1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>4.4.6-rc3</version>
+        <version>4.4.6-rc6</version>
     </parent>
     <artifactId>java-client-testing</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
- Update ProcessImpressionOptimized
- Change fetchAll name to fetchFromTheBeginning in SegmentFetcher.