### PR TITLE
Add provide for junit dependency in java-client-testing pom

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -22,6 +22,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Add scope provide for junit dependency in  java-client-testing pom