### PR TITLE
[SDKS-6101] Move UniqueKeysTracker start to SyncManager and SplitFactory

### DIFF
--- a/client/src/main/java/io/split/client/impressions/UniqueKeysTrackerImp.java
+++ b/client/src/main/java/io/split/client/impressions/UniqueKeysTrackerImp.java
@@ -52,12 +52,6 @@ public class UniqueKeysTrackerImp implements UniqueKeysTracker{
                 .build();
         _uniqueKeysSyncScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(uniqueKeysSyncThreadFactory);
         _cleanFilterScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(filterThreadFactory);
-
-        try {
-            this.start();
-        } catch (Exception e) {
-            _log.error("Error trying to init Unique Keys Tracker synchronizer task.", e);
-        }
     }
 
     @Override

--- a/client/src/test/java/io/split/client/impressions/ImpressionsManagerImplTest.java
+++ b/client/src/test/java/io/split/client/impressions/ImpressionsManagerImplTest.java
@@ -8,8 +8,6 @@ import io.split.storages.enums.OperationMode;
 import io.split.telemetry.domain.enums.ImpressionsDataTypeEnum;
 import io.split.telemetry.storage.InMemoryTelemetryStorage;
 import io.split.telemetry.storage.TelemetryStorage;
-import io.split.telemetry.synchronizer.TelemetryInMemorySubmitter;
-import io.split.telemetry.synchronizer.TelemetrySynchronizer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -62,9 +60,9 @@ public class ImpressionsManagerImplTest {
         ImpressionsStorage storage = new InMemoryImpressionsStorage(config.impressionsQueueSize());
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
+        UniqueKeysTracker uniqueKeysTracker = Mockito.mock(UniqueKeysTrackerImp.class);
 
-        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, telemetrySynchronizer);
+        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, uniqueKeysTracker);
         treatmentLog.start();
 
         KeyImpression ki1 = keyImpression("test1", "adil", "on", 1L, null);
@@ -98,9 +96,9 @@ public class ImpressionsManagerImplTest {
         ImpressionsStorage storage = new InMemoryImpressionsStorage(config.impressionsQueueSize());
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
+        UniqueKeysTracker uniqueKeysTracker = Mockito.mock(UniqueKeysTrackerImp.class);
 
-        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, telemetrySynchronizer);
+        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, uniqueKeysTracker);
         treatmentLog.start();
 
         // These 4 unique test name will cause 4 entries but we are caping at the first 3.
@@ -136,9 +134,9 @@ public class ImpressionsManagerImplTest {
         ImpressionsStorage storage = new InMemoryImpressionsStorage(config.impressionsQueueSize());
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
+        UniqueKeysTracker uniqueKeysTracker = Mockito.mock(UniqueKeysTrackerImp.class);
 
-        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, telemetrySynchronizer);
+        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, uniqueKeysTracker);
         treatmentLog.start();
 
         // These 4 unique test name will cause 4 entries but we are caping at the first 3.
@@ -176,9 +174,9 @@ public class ImpressionsManagerImplTest {
         ImpressionsStorage storage = new InMemoryImpressionsStorage(config.impressionsQueueSize());
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
+        UniqueKeysTracker uniqueKeysTracker = Mockito.mock(UniqueKeysTrackerImp.class);
 
-        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, telemetrySynchronizer);
+        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, uniqueKeysTracker);
 
         // There are no impressions to post.
 
@@ -199,9 +197,9 @@ public class ImpressionsManagerImplTest {
         ImpressionsStorage storage = new InMemoryImpressionsStorage(config.impressionsQueueSize());
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
+        UniqueKeysTracker uniqueKeysTracker = Mockito.mock(UniqueKeysTrackerImp.class);
 
-        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, telemetrySynchronizer);
+        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, uniqueKeysTracker);
 
         // These 4 unique test name will cause 4 entries but we are caping at the first 3.
         KeyImpression ki1 = keyImpression("test1", "adil", "on", 1L, 1L);
@@ -252,9 +250,9 @@ public class ImpressionsManagerImplTest {
         ImpressionsStorage storage = new InMemoryImpressionsStorage(config.impressionsQueueSize());
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
+        UniqueKeysTracker uniqueKeysTracker = Mockito.mock(UniqueKeysTrackerImp.class);
 
-        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, telemetrySynchronizer);
+        ImpressionsManagerImpl treatmentLog = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, uniqueKeysTracker);
         treatmentLog.start();
 
         // These 4 unique test name will cause 4 entries but we are caping at the first 3.
@@ -304,9 +302,9 @@ public class ImpressionsManagerImplTest {
         ImpressionsStorage storage = new InMemoryImpressionsStorage(config.impressionsQueueSize());
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
+        UniqueKeysTracker uniqueKeysTracker = Mockito.mock(UniqueKeysTrackerImp.class);
 
-        ImpressionsManagerImpl manager = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, telemetrySynchronizer);
+        ImpressionsManagerImpl manager = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, uniqueKeysTracker);
         manager.start();
         Assert.assertNotNull(manager.getCounter());
     }
@@ -323,9 +321,9 @@ public class ImpressionsManagerImplTest {
         ImpressionsStorage storage = new InMemoryImpressionsStorage(config.impressionsQueueSize());
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
+        UniqueKeysTracker uniqueKeysTracker = Mockito.mock(UniqueKeysTrackerImp.class);
 
-        ImpressionsManagerImpl manager = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, telemetrySynchronizer);
+        ImpressionsManagerImpl manager = ImpressionsManagerImpl.instanceForTest(config, senderMock, null, TELEMETRY_STORAGE, storage, storage, uniqueKeysTracker);
         manager.start();
         Assert.assertNotNull(manager.getCounter());
     }

--- a/client/src/test/java/io/split/client/impressions/UniqueKeysTrackerImpTest.java
+++ b/client/src/test/java/io/split/client/impressions/UniqueKeysTrackerImpTest.java
@@ -76,6 +76,7 @@ public class UniqueKeysTrackerImpTest {
     public void testSynchronization() throws Exception {
         TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
         UniqueKeysTrackerImp uniqueKeysTrackerImp = new UniqueKeysTrackerImp(telemetrySynchronizer, 1, 3);
+        uniqueKeysTrackerImp.start();
         Assert.assertTrue(uniqueKeysTrackerImp.track("feature1","key1"));
         Assert.assertTrue(uniqueKeysTrackerImp.track("feature1","key2"));
         Assert.assertTrue(uniqueKeysTrackerImp.track("feature2","key3"));
@@ -90,6 +91,7 @@ public class UniqueKeysTrackerImpTest {
     public void testStopSynchronization() throws Exception {
         TelemetrySynchronizer telemetrySynchronizer = Mockito.mock(TelemetryInMemorySubmitter.class);
         UniqueKeysTrackerImp uniqueKeysTrackerImp = new UniqueKeysTrackerImp(telemetrySynchronizer, 1, 2);
+        uniqueKeysTrackerImp.start();
         Assert.assertTrue(uniqueKeysTrackerImp.track("feature1","key1"));
         Assert.assertTrue(uniqueKeysTrackerImp.track("feature1","key2"));
         Assert.assertTrue(uniqueKeysTrackerImp.track("feature2","key3"));

--- a/client/src/test/java/io/split/engine/common/SyncManagerTest.java
+++ b/client/src/test/java/io/split/engine/common/SyncManagerTest.java
@@ -51,7 +51,7 @@ public class SyncManagerTest {
 
         Mockito.when(_synchronizer.syncAll()).thenReturn(true);
         SyncManagerImp syncManager = new SyncManagerImp( splitTasks, false, _synchronizer, _pushManager, new LinkedBlockingQueue<>(),
-                _gates, telemetryStorage, _telemetrySynchronizer, _config);
+                _gates, telemetryStorage, _telemetrySynchronizer, _config, null);
         syncManager.start();
         Thread.sleep(1000);
         Mockito.verify(_synchronizer, Mockito.times(1)).startPeriodicFetching();
@@ -67,7 +67,7 @@ public class SyncManagerTest {
 
         Mockito.when(_synchronizer.syncAll()).thenReturn(true);
         SyncManager sm = new SyncManagerImp(splitTasks, true, _synchronizer, _pushManager, new LinkedBlockingQueue<>(),
-                _gates, telemetryStorage, _telemetrySynchronizer, _config);
+                _gates, telemetryStorage, _telemetrySynchronizer, _config, null);
         sm.start();
         Thread.sleep(1000);
         Mockito.verify(_synchronizer, Mockito.times(0)).startPeriodicFetching();
@@ -84,7 +84,7 @@ public class SyncManagerTest {
                 _impressionsManager, _eventsTask, _telemetrySyncTask);
 
         SyncManagerImp syncManager = new SyncManagerImp(splitTasks, true, _synchronizer, _pushManager, messages,
-                _gates, telemetryStorage, _telemetrySynchronizer, _config);
+                _gates, telemetryStorage, _telemetrySynchronizer, _config, null);
         Thread t = new Thread(syncManager::incomingPushStatusHandler);
         t.start();
         messages.offer(PushManager.Status.STREAMING_READY);
@@ -104,7 +104,7 @@ public class SyncManagerTest {
                 _impressionsManager, _eventsTask, _telemetrySyncTask);
 
         SyncManagerImp syncManager = new SyncManagerImp(splitTasks, true, _synchronizer, _pushManager, messsages,
-                _gates, telemetryStorage, _telemetrySynchronizer, _config);
+                _gates, telemetryStorage, _telemetrySynchronizer, _config, null);
         Thread t = new Thread(syncManager::incomingPushStatusHandler);
         t.start();
         messsages.offer(PushManager.Status.STREAMING_DOWN);
@@ -123,7 +123,7 @@ public class SyncManagerTest {
                 _impressionsManager, _eventsTask, _telemetrySyncTask);
 
         SyncManagerImp syncManager = new SyncManagerImp(splitTasks, true, _synchronizer, _pushManager, messsages,
-                _gates, telemetryStorage, _telemetrySynchronizer, _config);
+                _gates, telemetryStorage, _telemetrySynchronizer, _config, null);
         Thread t = new Thread(syncManager::incomingPushStatusHandler);
         t.start();
         messsages.offer(PushManager.Status.STREAMING_OFF);
@@ -140,7 +140,7 @@ public class SyncManagerTest {
                 _impressionsManager, _eventsTask, _telemetrySyncTask);
 
         SyncManagerImp syncManager = new SyncManagerImp(splitTasks, true, _synchronizer, _pushManager, messsages,
-                _gates, telemetryStorage, _telemetrySynchronizer, _config);
+                _gates, telemetryStorage, _telemetrySynchronizer, _config, null);
         Thread t = new Thread(syncManager::incomingPushStatusHandler);
         t.start();
         messsages.offer(PushManager.Status.STREAMING_READY);
@@ -158,7 +158,7 @@ public class SyncManagerTest {
                 _impressionsManager, _eventsTask, _telemetrySyncTask);
 
         SyncManagerImp syncManager = new SyncManagerImp(splitTasks, true, _synchronizer, _pushManager, messsages,
-                _gates, telemetryStorage, _telemetrySynchronizer, _config);
+                _gates, telemetryStorage, _telemetrySynchronizer, _config, null);
         Thread t = new Thread(syncManager::incomingPushStatusHandler);
         t.start();
         messsages.offer(PushManager.Status.STREAMING_OFF);
@@ -176,7 +176,7 @@ public class SyncManagerTest {
 
         Mockito.when(_synchronizer.syncAll()).thenReturn(true);
         SyncManagerImp syncManager = new SyncManagerImp(splitTasks, true, _synchronizer, _pushManager, messsages,
-                _gates, telemetryStorage, _telemetrySynchronizer, _config);
+                _gates, telemetryStorage, _telemetrySynchronizer, _config, null);
         syncManager.start();
         messsages.offer(PushManager.Status.STREAMING_BACKOFF);
         Thread.sleep(1200);
@@ -193,7 +193,7 @@ public class SyncManagerTest {
 
         Mockito.when(_synchronizer.syncAll()).thenReturn(false).thenReturn(true);
         SyncManagerImp syncManager = new SyncManagerImp(splitTasks, false, _synchronizer, _pushManager, new LinkedBlockingQueue<>(),
-                _gates, telemetryStorage, _telemetrySynchronizer, _config);
+                _gates, telemetryStorage, _telemetrySynchronizer, _config, null);
         syncManager.start();
         Thread.sleep(2000);
         Mockito.verify(_synchronizer, Mockito.times(1)).startPeriodicFetching();


### PR DESCRIPTION
After merging the destroy refactor, I moved the start UniqueKeys to SyncManager and created UniqueKeysTracker in SplitFactory.