### PR TITLE
Shaded and non shaded versions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+4.9.0 (Aug 3, 2023)
+- Shuffled maven poms around to release both a client only jar and a client with dependencies version
+
 4.8.1 (Aug 1, 2023)
 - Applied linting rules to the code.
 - Fixed an issue when the prefix is empty for Redis settings.

--- a/client-with-deps/pom.xml
+++ b/client-with-deps/pom.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -7,10 +8,10 @@
         <artifactId>java-client-parent</artifactId>
         <version>4.8.1</version>
     </parent>
-    <artifactId>java-client</artifactId>
+    <artifactId>java-client-with-deps</artifactId>
     <packaging>jar</packaging>
-    <name>Java Client</name>
-    <description>Java SDK for Split</description>
+    <name>Java Client With Dependencies</name>
+    <description>Java SDK for Split with Dependencies bundled</description>
 
     <profiles>
         <profile>
@@ -42,6 +43,78 @@
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
                 </configuration>
+            </plugin>
+            <!-- Shade dependencies to avoid conflicts with other customer's libs -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>false</minimizeJar>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <artifactSet>
+                                <includes>
+                                    <include>io.split.engine:*</include>
+                                    <include>io.split.client:*</include>
+                                    <include>io.split.schemas:*</include>
+                                    <include>io.codigo.grammar:*</include>
+                                    <include>org.apache.httpcomponents.*</include>
+                                    <include>com.google.*</include>
+                                    <include>org.yaml:snakeyaml:*</include>
+
+                                    <!-- Transitive dependency of guava -->
+                                    <include>org.checkerframework:*</include>
+
+                                    <!-- Transitive dependency of httpclient5. Package name is org.apache.commons -->
+                                    <include>commons-codec:*</include>
+                                </includes>
+                            </artifactSet>
+                            <transformers>
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache</pattern>
+                                    <shadedPattern>split.org.apache</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.checkerframework</pattern>
+                                    <shadedPattern>split.org.checkerframework</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.yaml.snakeyaml</pattern>
+                                    <shadedPattern>split.org.yaml.snakeyaml</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>split.com.google</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/license/**</exclude>
+                                        <exclude>META-INF/*</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                        <exclude>META-INF/services/**</exclude>
+                                        <exclude>LICENSE</exclude>
+                                        <exclude>NOTICE</exclude>
+                                        <exclude>/*.txt</exclude>
+                                        <exclude>build.properties</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/client-with-deps/pom.xml
+++ b/client-with-deps/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>4.8.1</version>
+        <version>4.9.0</version>
     </parent>
     <artifactId>java-client-with-deps</artifactId>
     <packaging>jar</packaging>

--- a/client-with-deps/pom.xml
+++ b/client-with-deps/pom.xml
@@ -148,80 +148,9 @@
     <dependencies>
         <dependency>
             <groupId>io.split.client</groupId>
-            <artifactId>pluggable-storage</artifactId>
+            <artifactId>java-client</artifactId>
+            <version>${project.version}</version>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-        </dependency>
-
-        <!-- Test deps -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-sse</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-grizzly2-http</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/client-with-deps/pom.xml
+++ b/client-with-deps/pom.xml
@@ -119,6 +119,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/client-with-deps/src/main/resources/splitversion.properties
+++ b/client-with-deps/src/main/resources/splitversion.properties
@@ -1,0 +1,1 @@
+sdk.version=${project.version}

--- a/client/README.md
+++ b/client/README.md
@@ -4,7 +4,7 @@ This SDK is designed to work with [Split](https://www.split.io), the platform fo
 
 ### Quick setup
 
-For specific instructions on how to set up the Split SDK refer to our [official SDK documentation](http://docs.split.io/docs/sdk-overview).
+For specific instructions on how to set up the Split SDK refer to our [official SDK documentation](https://help.split.io/hc/en-us/articles/360020405151-Java-SDK).
 
 ### Commitment to Quality:
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -57,6 +57,8 @@
                         <configuration>
                             <minimizeJar>false</minimizeJar>
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>with-deps</shadedClassifierName>
                             <artifactSet>
                                 <includes>
                                     <include>io.split.engine:*</include>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -46,6 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+	            <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>4.8.1</version>
+        <version>4.9.0</version>
     </parent>
     <artifactId>java-client</artifactId>
     <packaging>jar</packaging>

--- a/pluggable-storage/pom.xml
+++ b/pluggable-storage/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>java-client-parent</artifactId>
         <groupId>io.split.client</groupId>
-        <version>4.8.1</version>
+        <version>4.9.0</version>
     </parent>
 
     <version>2.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.split.client</groupId>
     <artifactId>java-client-parent</artifactId>
-    <version>4.8.1</version>
+    <version>4.9.0</version>
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,87 @@
                 <artifactId>junit</artifactId>
                 <version>4.13.1</version>
             </dependency>
+            <dependency>
+                <groupId>io.split.client</groupId>
+                <artifactId>pluggable-storage</artifactId>
+                <version>2.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.1-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>5.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.9.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.0</version>
+            </dependency>
+
+            <!-- Test deps -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>1.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>1.10.19</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-sse</artifactId>
+                <version>2.31</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
+                <version>2.31</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.containers</groupId>
+                <artifactId>jersey-container-grizzly2-http</artifactId>
+                <version>2.26</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>mockwebserver</artifactId>
+                <version>4.8.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>4.0.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <packaging>pom</packaging>
-    <name>Java Client</name>
+    <name>Split IO Java Client Parent</name>
     <description>Java SDK for Split</description>
     <url>www.split.io</url>
     <developers>
@@ -79,13 +156,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <slf4j.api.version>1.7.36</slf4j.api.version>
     </properties>
     <modules>
         <module>testing</module>
         <module>client</module>
         <module>pluggable-storage</module>
         <module>redis-wrapper</module>
+        <module>client-with-deps</module>
     </modules>
+
     <build>
         <plugins>
             <plugin>
@@ -150,6 +230,7 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/redis-wrapper/pom.xml
+++ b/redis-wrapper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>java-client-parent</artifactId>
         <groupId>io.split.client</groupId>
-        <version>4.8.1</version>
+        <version>4.9.0</version>
     </parent>
     <artifactId>redis-wrapper</artifactId>
     <version>3.0.1</version>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>4.8.1</version>
+        <version>4.9.0</version>
     </parent>
     <artifactId>java-client-testing</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
Corrects the url of the sdk documentation as the given url does not work.

Minor fix added to specify the version number for the `maven-source-plugin` 

I also bumped the version to ensure I had some maven settings correct.

I was not able to run the redis module tests as that seems to be an integration test requiring some infrastructure.

The pom will now create a shaded version `java-client-with-deps` and a non-shaded version at `java-client`. 

In this version, documentation referencing the shaded version's maven coordinates would have to change from this:
``` xml
            <dependency>
                <groupId>io.split.client</groupId>
                <artifactId>java-client</artifactId>
                <version>4.9.0</version>
            </dependency>
```

to this

``` xml
            <dependency>
                <groupId>io.split.client</groupId>
                <artifactId>java-client-with-deps</artifactId>
                <version>4.9.0</version>
            </dependency>
``` 

The original maven coordinates would be for the non-shaded version.

Why do this?
Simpler management of dependencies with tools like scanning for vulnerabilities and updates.