### PR TITLE
[SDKS-7788] Some flag set fixes

### DIFF
--- a/client/src/main/java/io/split/client/SplitClient.java
+++ b/client/src/main/java/io/split/client/SplitClient.java
@@ -256,7 +256,7 @@ public interface SplitClient {
     Map<String, SplitResult> getTreatmentsWithConfig(String key, List<String> featureFlagNames, Map<String, Object> attributes);
 
     /**
-     * Same as {@link #getTreatments(Key, List<String>, Map)} but it returns for each feature flag the configuration associated to the
+     * Same as {@link #getTreatments(Key, List, Map)} but it returns for each feature flag the configuration associated to the
      * matching treatment if any. Otherwise {@link SplitResult.configurations()} will be null.
      *
      * @param key the matching and bucketing keys. MUST NOT be null.
@@ -267,6 +267,21 @@ public interface SplitClient {
      *         a configuration associated to this treatment if set.
      */
     Map<String, SplitResult> getTreatmentsWithConfig(Key key, List<String> featureFlagNames, Map<String, Object> attributes);
+
+    /**
+     * Same as {@link #getTreatments(String, List<String>, Map)} but it returns for each feature flag the configuration associated to the
+     * matching treatment if any. Otherwise {@link SplitResult.configurations()} will be null.
+     * <p/>
+     * <p/>
+     * Examples include showing a different treatment to users on trial plan
+     * vs. premium plan. Another example is to show a different treatment
+     * to users created after a certain date.
+     *
+     * @param key a unique key of your customer (e.g. user_id, user_email, account_id, etc.) MUST not be null or empty.
+     * @param flagSet the Flag Set name that you want to evaluate. MUST not be null or empty.
+     * @return for each feature flag the evaluated treatment, the default treatment of this feature flag, or 'control'.
+     */
+    Map<String, String> getTreatmentsByFlagSet(String key, String flagSet);
 
     /**
      * Same as {@link #getTreatments(String, List<String>, Map)} but it returns for each feature flag the configuration associated to the
@@ -311,6 +326,21 @@ public interface SplitClient {
      *
      * @param key a unique key of your customer (e.g. user_id, user_email, account_id, etc.) MUST not be null or empty.
      * @param flagSets  the names of Flag Sets that you want to evaluate. MUST not be null or empty.
+     * @return for each feature flag the evaluated treatment, the default treatment of this feature flag, or 'control'.
+     */
+    Map<String, String> getTreatmentsByFlagSets(String key, List<String> flagSets);
+
+    /**
+     * Same as {@link #getTreatments(String, List<String>, Map)} but it returns for each feature flag the configuration associated to the
+     * matching treatment if any. Otherwise {@link SplitResult.configurations()} will be null.
+     * <p/>
+     * <p/>
+     * Examples include showing a different treatment to users on trial plan
+     * vs. premium plan. Another example is to show a different treatment
+     * to users created after a certain date.
+     *
+     * @param key a unique key of your customer (e.g. user_id, user_email, account_id, etc.) MUST not be null or empty.
+     * @param flagSets  the names of Flag Sets that you want to evaluate. MUST not be null or empty.
      * @param attributes of the customer (user, account etc.) to use in evaluation. Can be null or empty.
      * @return for each feature flag the evaluated treatment, the default treatment of this feature flag, or 'control'.
      */
@@ -331,6 +361,22 @@ public interface SplitClient {
      * @return for each feature flag the evaluated treatment, the default treatment of this feature flag, or 'control'.
      */
     Map<String, String> getTreatmentsByFlagSets(Key key, List<String> flagSets, Map<String, Object> attributes);
+
+    /**
+     * Same as {@link #getTreatments(String, List<String>, Map)} but it returns for each feature flag the configuration associated to the
+     * matching treatment if any. Otherwise {@link SplitResult.configurations()} will be null.
+     * <p/>
+     * <p/>
+     * Examples include showing a different treatment to users on trial plan
+     * vs. premium plan. Another example is to show a different treatment
+     * to users created after a certain date.
+     *
+     * @param key a unique key of your customer (e.g. user_id, user_email, account_id, etc.) MUST not be null or empty.
+     * @param flagSet  the Flag Set name that you want to evaluate. MUST not be null or empty.
+     * @return for each feature flag the evaluated treatment (the default treatment of this feature flag, or 'control') and a configuration
+     * associated to this treatment if set.
+     */
+    Map<String, SplitResult> getTreatmentsWithConfigByFlagSet(String key, String flagSet);
 
     /**
      * Same as {@link #getTreatments(String, List<String>, Map)} but it returns for each feature flag the configuration associated to the
@@ -365,6 +411,22 @@ public interface SplitClient {
      * associated to this treatment if set.
      */
     Map<String, SplitResult> getTreatmentsWithConfigByFlagSet(Key key, String flagSet, Map<String, Object> attributes);
+
+    /**
+     * Same as {@link #getTreatments(String, List<String>, Map)} but it returns for each feature flag the configuration associated to the
+     * matching treatment if any. Otherwise {@link SplitResult.configurations()} will be null.
+     * <p/>
+     * <p/>
+     * Examples include showing a different treatment to users on trial plan
+     * vs. premium plan. Another example is to show a different treatment
+     * to users created after a certain date.
+     *
+     * @param key a unique key of your customer (e.g. user_id, user_email, account_id, etc.) MUST not be null or empty.
+     * @param flagSets  the names of Flag Sets that you want to evaluate. MUST not be null or empty.
+     * @return for each feature flag the evaluated treatment (the default treatment of this feature flag, or 'control') and a configuration
+     * associated to this treatment if set.
+     */
+    Map<String, SplitResult> getTreatmentsWithConfigByFlagSets(String key, List<String> flagSets);
 
     /**
      * Same as {@link #getTreatments(String, List<String>, Map)} but it returns for each feature flag the configuration associated to the
@@ -444,7 +506,6 @@ public interface SplitClient {
      * @param key the identifier of the entity
      * @param trafficType the type of the event
      * @param eventType the type of the event
-     * @param value the value of the event
      *
      * @return true if the track was successful, false otherwise
      */

--- a/client/src/main/java/io/split/inputValidation/FlagSetsValidator.java
+++ b/client/src/main/java/io/split/inputValidation/FlagSetsValidator.java
@@ -33,7 +33,7 @@ public final class FlagSetsValidator {
             }
             if (!Pattern.matches(FLAG_SET_REGEX, flagSet)) {
                 _log.warn(String.format("you passed %s, Flag Set must adhere to the regular expressions %s. This means a Flag Set must be " +
-                        "start with a letter, be in lowercase, alphanumeric and have a max length of 50 characters. %s was discarded.",
+                        "start with a letter or number, be in lowercase, alphanumeric and have a max length of 50 characters. %s was discarded.",
                         flagSet, FLAG_SET_REGEX, flagSet));
                 continue;
             }

--- a/client/src/main/java/io/split/storages/memory/InMemoryCacheImp.java
+++ b/client/src/main/java/io/split/storages/memory/InMemoryCacheImp.java
@@ -110,9 +110,7 @@ public class InMemoryCacheImp implements SplitCache {
         Map<String, HashSet<String>> toReturn = new HashMap<>();
         for (String set: flagSets) {
             HashSet<String> keys = _flagSets.get(set);
-            if(keys != null){
-                toReturn.put(set, keys);
-            }
+            toReturn.put(set, keys);
         }
         return toReturn;
     }

--- a/client/src/test/java/io/split/client/SplitClientImplTest.java
+++ b/client/src/test/java/io/split/client/SplitClientImplTest.java
@@ -1955,7 +1955,7 @@ public class SplitClientImplTest {
         fetchManyResult.put(test2, parsedSplit2);
         when(splitCacheConsumer.fetchMany(new ArrayList<>(Arrays.asList(test2, test)))).thenReturn(fetchManyResult);
 
-        List<String> sets = new ArrayList<>(Arrays.asList("set1", "set3"));
+        List<String> sets = new ArrayList<>(Arrays.asList("set3", "set1"));
         Map<String, HashSet<String>> flagsBySets = new HashMap<>();
         flagsBySets.put("set1", new HashSet<>(Arrays.asList(test)));
         flagsBySets.put("set3", new HashSet<>(Arrays.asList(test2)));

--- a/client/src/test/java/io/split/storages/memory/InMemoryCacheTest.java
+++ b/client/src/test/java/io/split/storages/memory/InMemoryCacheTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class InMemoryCacheTest {
@@ -229,7 +230,8 @@ public class InMemoryCacheTest {
         assertTrue(namesByFlagSets.get("set1").contains("splitName_2"));
         assertFalse(namesByFlagSets.get("set1").contains("splitName_3"));
         assertFalse(namesByFlagSets.get("set1").contains("splitName_4"));
-        assertFalse(namesByFlagSets.keySet().contains("set3"));
+        assertTrue(namesByFlagSets.keySet().contains("set3"));
+        assertNull(namesByFlagSets.get("set3"));
 
         _cache.remove("splitName_2");
         namesByFlagSets = _cache.getNamesByFlagSets(new ArrayList<>(Arrays.asList("set1", "set2", "set3")));

--- a/testing/src/main/java/io/split/client/testing/SplitClientForTest.java
+++ b/testing/src/main/java/io/split/client/testing/SplitClientForTest.java
@@ -133,6 +133,11 @@ public class SplitClientForTest implements SplitClient {
     }
 
     @Override
+    public Map<String, String> getTreatmentsByFlagSet(String key, String flagSet) {
+        return null;
+    }
+
+    @Override
     public Map<String, String> getTreatmentsByFlagSet(String key, String flagSet, Map<String, Object> attributes) {
         return new HashMap<>();
     }
@@ -140,6 +145,11 @@ public class SplitClientForTest implements SplitClient {
     @Override
     public Map<String, String> getTreatmentsByFlagSet(Key key, String flagSet, Map<String, Object> attributes) {
         return new HashMap<>();
+    }
+
+    @Override
+    public Map<String, String> getTreatmentsByFlagSets(String key, List<String> flagSets) {
+        return null;
     }
 
     @Override
@@ -153,6 +163,11 @@ public class SplitClientForTest implements SplitClient {
     }
 
     @Override
+    public Map<String, SplitResult> getTreatmentsWithConfigByFlagSet(String key, String flagSet) {
+        return null;
+    }
+
+    @Override
     public Map<String, SplitResult> getTreatmentsWithConfigByFlagSet(String key, String flagSet, Map<String, Object> attributes) {
         return new HashMap<>();
     }
@@ -160,6 +175,11 @@ public class SplitClientForTest implements SplitClient {
     @Override
     public Map<String, SplitResult> getTreatmentsWithConfigByFlagSet(Key key, String flagSet, Map<String, Object> attributes) {
         return new HashMap<>();
+    }
+
+    @Override
+    public Map<String, SplitResult> getTreatmentsWithConfigByFlagSets(String key, List<String> flagSets) {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
- Updated to return null if the set doesn't have flags in getNamesByFlagSets
- Assigned in flagSets if the sets are in the config, before getting all flags in getTreatmentsBySetsWithConfigInternal
- Updated log:
Flag Set must adhere to the regular expressions {SetExpectedRegex}. This means a Flag Set must start with a letter or number, be in lowercase, alphanumeric and have a max length of 50 characters. {set} was discarded.
- Added getTreaments without attributes param