### PR TITLE
feat: add ProcessImpressionNoOp to ignore impressions entirely

### DIFF
--- a/client/src/main/java/io/split/client/SplitFactoryImpl.java
+++ b/client/src/main/java/io/split/client/SplitFactoryImpl.java
@@ -23,6 +23,7 @@ import io.split.client.impressions.PluggableImpressionSender;
 import io.split.client.impressions.UniqueKeysTracker;
 import io.split.client.impressions.UniqueKeysTrackerImp;
 import io.split.client.impressions.strategy.ProcessImpressionDebug;
+import io.split.client.impressions.strategy.ProcessImpressionNoOp;
 import io.split.client.impressions.strategy.ProcessImpressionNone;
 import io.split.client.impressions.strategy.ProcessImpressionOptimized;
 import io.split.client.impressions.strategy.ProcessImpressionStrategy;
@@ -607,6 +608,8 @@ public class SplitFactoryImpl implements SplitFactory {
                 counter = new ImpressionCounter();
                 processImpressionStrategy = new ProcessImpressionNone(listener != null, _uniqueKeysTracker, counter);
                 break;
+            case NOOP:
+                processImpressionStrategy = new ProcessImpressionNoOp();
         }
         return ImpressionsManagerImpl.instance(config, _telemetryStorageProducer, impressionsStorageConsumer, impressionsStorageProducer,
                 _impressionsSender, processImpressionStrategy, counter, listener);

--- a/client/src/main/java/io/split/client/impressions/ImpressionsManager.java
+++ b/client/src/main/java/io/split/client/impressions/ImpressionsManager.java
@@ -7,7 +7,8 @@ public interface ImpressionsManager {
     public enum Mode {
         OPTIMIZED,
         DEBUG,
-        NONE
+        NONE,
+        NOOP
     }
 
     void track(List<Impression> impressions);

--- a/client/src/main/java/io/split/client/impressions/strategy/ProcessImpressionNoOp.java
+++ b/client/src/main/java/io/split/client/impressions/strategy/ProcessImpressionNoOp.java
@@ -1,0 +1,14 @@
+package io.split.client.impressions.strategy;
+
+import io.split.client.impressions.Impression;
+import io.split.client.impressions.ImpressionsResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProcessImpressionNoOp implements ProcessImpressionStrategy {
+    @Override
+    public ImpressionsResult process(List<Impression> impressions) {
+        return new ImpressionsResult(new ArrayList<>(), null);
+    }
+}


### PR DESCRIPTION
Allows for bypassing impression tracking, solving the problem reported in #473 