### PR TITLE
feat: Add GraalVM native-image support by removing Guava shading

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,9 +5,9 @@
     <parent>
         <groupId>io.split.client</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>4.18.2</version>
+        <version>4.18.2-graalvm</version>
     </parent>
-    <version>4.18.2</version>
+    <version>4.18.2-graalvm</version>
     <artifactId>java-client</artifactId>
     <packaging>jar</packaging>
     <name>Java Client</name>
@@ -70,11 +70,13 @@
                                     <include>org.apache.httpcomponents.*</include>
                                     <include>org.apache.hc.*</include>
                                     <include>com.google.code.gson:gson</include>
-                                    <include>com.google.guava:guava</include>
+                                    <!-- REMOVED for GraalVM native-image support: Guava remains as transitive dependency -->
+                                    <!-- <include>com.google.guava:guava</include> -->
                                     <include>org.yaml:snakeyaml:*</include>
 
                                     <!-- Transitive dependency of guava -->
-                                    <include>org.checkerframework:*</include>
+                                    <!-- REMOVED for GraalVM native-image support: transitive dependency of guava -->
+                                    <!-- <include>org.checkerframework:*</include> -->
 
                                     <!-- Transitive dependency of httpclient5. Package name is org.apache.commons -->
                                     <include>commons-codec:*</include>
@@ -89,18 +91,24 @@
                                     <pattern>org.apache</pattern>
                                     <shadedPattern>split.org.apache</shadedPattern>
                                 </relocation>
+                                <!-- REMOVED for GraalVM native-image support: transitive dependency of guava -->
+                                <!--
                                 <relocation>
                                     <pattern>org.checkerframework</pattern>
                                     <shadedPattern>split.org.checkerframework</shadedPattern>
                                 </relocation>
+                                -->
                                 <relocation>
                                     <pattern>org.yaml.snakeyaml</pattern>
                                     <shadedPattern>split.org.yaml.snakeyaml</shadedPattern>
                                 </relocation>
+                                <!-- REMOVED for GraalVM native-image support: standard Guava has native-image config -->
+                                <!--
                                 <relocation>
                                     <pattern>com.google</pattern>
                                     <shadedPattern>split.com.google</shadedPattern>
                                 </relocation>
+                                -->
                             </relocations>
                             <filters>
                                 <filter>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.split.client</groupId>
     <artifactId>java-client-parent</artifactId>
-    <version>4.18.2</version>
+    <version>4.18.2-graalvm</version>
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
This commit enables GraalVM native-image compilation for applications using the Split.io Java SDK.

Problem:
The Split SDK shades Guava to split.com.google.common.* to avoid dependency conflicts. However, this shaded Guava lacks the GraalVM native-image configuration that standard Guava provides, causing build failures with errors like:
  'Discovered unresolved type: split.com.google.common.util.concurrent.SettableFuture'

Root Cause:
Standard Guava (com.google.common.*) includes GraalVM native-image configuration in META-INF/native-image/. When the SDK shades Guava to split.com.google.common.*, this configuration is lost.

Solution:
Remove Guava from the shade plugin configuration. Guava remains as a transitive dependency, allowing applications to use the standard Guava library which has proper GraalVM native-image support.

Changes:
- Remove com.google.guava:guava from shade plugin includes
- Remove org.checkerframework:* from shade plugin includes
- Remove com.google -> split.com.google relocation
- Remove org.checkerframework -> split.org.checkerframework relocation
- Update version to 4.18.2-graalvm to distinguish from upstream

Testing:
- Built native image with Quarkus 3.27.1 + Mandrel JDK-23
- Verified Split client works correctly at runtime
- Tested feature flag resolution in native image

Reference: https://github.com/splitio/java-client/pull/614