### PR TITLE
[FME-17694] Bump java-client-testing to 5.0.0-rc with per-key treatment support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
     <modules>
         <module>pluggable-storage</module>
         <module>redis-wrapper</module>
+        <module>testing</module>
         <module>okhttp-modules</module>
         <module>client</module>
-        <module>testing</module>
     </modules>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
     <modules>
         <module>pluggable-storage</module>
         <module>redis-wrapper</module>
-        <module>testing</module>
         <module>okhttp-modules</module>
         <module>client</module>
+        <module>testing</module>
     </modules>
     <build>
         <plugins>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>java-client-testing</artifactId>
     <packaging>jar</packaging>
-    <version>5.0.0-rc</version>
+    <version>5.0.0</version>
     <name>Java Client For Testing</name>
     <description>Testing suite for Java SDK for Split</description>
     <dependencies>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -9,14 +9,14 @@
     </parent>
     <artifactId>java-client-testing</artifactId>
     <packaging>jar</packaging>
-    <version>4.18.3</version>
+    <version>5.0.0-rc</version>
     <name>Java Client For Testing</name>
     <description>Testing suite for Java SDK for Split</description>
     <dependencies>
         <dependency>
             <groupId>io.split.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>${project.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/testing/src/main/java/io/split/client/testing/SplitClientForTest.java
+++ b/testing/src/main/java/io/split/client/testing/SplitClientForTest.java
@@ -21,19 +21,8 @@ public class SplitClientForTest implements SplitClient {
         _tests = new HashMap<>();
     }
 
-    public Map<String, String> tests() {
-        return _tests
-            .entrySet()
-            .stream()
-            .collect(toMap(
-                entry -> entry.getKey().split(),
-                entry -> entry.getValue().treatment(),
-                (existing, replacement) -> existing
-            ));
-    }
-
-    public Map<SplitAndKey, SplitResult> testMappings() {
-        return Collections.unmodifiableMap(_tests);
+    public Map<SplitAndKey, SplitResult> tests() {
+        return _tests;
     }
 
     public void clearTreatments() {

--- a/testing/src/main/java/io/split/client/testing/runner/RunWithSplits.java
+++ b/testing/src/main/java/io/split/client/testing/runner/RunWithSplits.java
@@ -26,7 +26,7 @@ public class RunWithSplits extends Statement {
         SplitClientForTest splitClient = findFirstSplitClient(target, target.getClass());
 
         // Preserve the Split state between Test runs
-        Map<SplitAndKey, SplitResult> priorTests = new HashMap<>(splitClient.testMappings());
+        Map<SplitAndKey, SplitResult> priorTests = new HashMap<>(splitClient.tests());
 
         // Apply the Active Scenario for this
         if (scenario != null) {

--- a/testing/src/test/java/io/split/client/testing/SplitScenarioAnnotationTest.java
+++ b/testing/src/test/java/io/split/client/testing/SplitScenarioAnnotationTest.java
@@ -1,6 +1,5 @@
 package io.split.client.testing;
 
-import com.google.common.collect.ImmutableMap;
 import io.split.client.api.Key;
 import io.split.client.api.SplitResult;
 import io.split.client.dtos.EvaluationOptions;
@@ -15,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Objects;
 
@@ -97,11 +97,11 @@ public class SplitScenarioAnnotationTest extends SplitAnnotationTestParent {
         Assert.assertEquals(new SplitResult(ON_TREATMENT, null), splitClient.getTreatmentWithConfig(ARBITRARY_KEY, DEFAULT_CLIENT_FEATURE, new HashMap<>(), new EvaluationOptions(new HashMap<>())));
         Assert.assertEquals(new SplitResult(ON_TREATMENT, null), splitClient.getTreatmentWithConfig(ARBITRARY_KEY, DEFAULT_CLIENT_FEATURE, new EvaluationOptions(new HashMap<>())));
         Assert.assertEquals(new SplitResult(ON_TREATMENT, null), splitClient.getTreatmentWithConfig(new Key(ARBITRARY_KEY, ARBITRARY_KEY), DEFAULT_CLIENT_FEATURE, new HashMap<>(), new EvaluationOptions(new HashMap<>())));
-        Assert.assertEquals(ImmutableMap.of(DEFAULT_CLIENT_FEATURE, ON_TREATMENT), splitClient.getTreatments(ARBITRARY_KEY, Arrays.asList(DEFAULT_CLIENT_FEATURE), new EvaluationOptions(new HashMap<>())));
-        Assert.assertEquals(ImmutableMap.of(DEFAULT_CLIENT_FEATURE, ON_TREATMENT), splitClient.getTreatments(ARBITRARY_KEY, Arrays.asList(DEFAULT_CLIENT_FEATURE),  new HashMap<>(), new EvaluationOptions(new HashMap<>())));
-        Assert.assertEquals(ImmutableMap.of(DEFAULT_CLIENT_FEATURE, new SplitResult(ON_TREATMENT, null)), splitClient.getTreatmentsWithConfig(ARBITRARY_KEY, Arrays.asList(DEFAULT_CLIENT_FEATURE), new EvaluationOptions(new HashMap<>())));
+        Assert.assertEquals(Collections.singletonMap(DEFAULT_CLIENT_FEATURE, ON_TREATMENT), splitClient.getTreatments(ARBITRARY_KEY, Arrays.asList(DEFAULT_CLIENT_FEATURE), new EvaluationOptions(new HashMap<>())));
+        Assert.assertEquals(Collections.singletonMap(DEFAULT_CLIENT_FEATURE, ON_TREATMENT), splitClient.getTreatments(ARBITRARY_KEY, Arrays.asList(DEFAULT_CLIENT_FEATURE),  new HashMap<>(), new EvaluationOptions(new HashMap<>())));
+        Assert.assertEquals(Collections.singletonMap(DEFAULT_CLIENT_FEATURE, new SplitResult(ON_TREATMENT, null)), splitClient.getTreatmentsWithConfig(ARBITRARY_KEY, Arrays.asList(DEFAULT_CLIENT_FEATURE), new EvaluationOptions(new HashMap<>())));
         Assert.assertEquals(new SplitResult(ON_TREATMENT, null), splitClient.getTreatmentsWithConfig(ARBITRARY_KEY, Arrays.asList(DEFAULT_CLIENT_FEATURE),  new HashMap<>(), new EvaluationOptions(new HashMap<>())).get(DEFAULT_CLIENT_FEATURE));
-        Assert.assertEquals(ImmutableMap.of(DEFAULT_CLIENT_FEATURE, new SplitResult(ON_TREATMENT, null)), splitClient.getTreatmentsWithConfig(new Key(ARBITRARY_KEY, ARBITRARY_KEY), Arrays.asList(DEFAULT_CLIENT_FEATURE),  new HashMap<>(), new EvaluationOptions(new HashMap<>())));
+        Assert.assertEquals(Collections.singletonMap(DEFAULT_CLIENT_FEATURE, new SplitResult(ON_TREATMENT, null)), splitClient.getTreatmentsWithConfig(new Key(ARBITRARY_KEY, ARBITRARY_KEY), Arrays.asList(DEFAULT_CLIENT_FEATURE),  new HashMap<>(), new EvaluationOptions(new HashMap<>())));
 
         Assert.assertEquals(new HashMap<>(), splitClient.getTreatmentsByFlagSet(ARBITRARY_KEY, "flagset",  new HashMap<>(), new EvaluationOptions(new HashMap<>())));
         Assert.assertEquals(new HashMap<>(), splitClient.getTreatmentsByFlagSet(ARBITRARY_KEY, "flagset", new EvaluationOptions(new HashMap<>())));


### PR DESCRIPTION
- `SplitClientForTest.tests()` now returns `Map<SplitAndKey, SplitResult>` instead of `Map<String, String>`, removing the separate `testMappings()` method
- Replaced Guava `ImmutableMap` with [Collections.singletonMap](url) in tests to remove external dependency
- Bumped `java-client-testing` to `5.0.0`, decoupled from parent version using `${project.parent.version}` for the java-client dependency